### PR TITLE
#24 update defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,9 @@ jobs:
       - name: Setup CargoWall
         uses: ./
         with:
-          default-action: deny
           allowed-hosts: |
-            github.com,
-            githubusercontent.com,
+            github.com
+            githubusercontent.com
             api.github.com
 
       - name: Test allowed connection (github.com)
@@ -63,13 +62,12 @@ jobs:
         uses: ./
         with:
           api-url: https://app.dev.codecargo.dev
-          default-action: deny
           allowed-hosts: |
-            app.dev.codecargo.dev,
-            github.com,
+            app.dev.codecargo.dev
+            github.com
             api.github.com
-            
-    
+
+
 
       - name: Test allowed DNS query
         run: |
@@ -102,10 +100,9 @@ jobs:
         uses: ./
         with:
           api-url: https://app.dev.codecargo.dev
-          default-action: deny
           allowed-cidrs: "140.82.112.0/20"  # GitHub's IP range
           allowed-hosts:
-            app.dev.codecargo.dev,
+            app.dev.codecargo.dev
             github.com
 
       - name: Test connection to allowed CIDR
@@ -125,9 +122,8 @@ jobs:
         uses: ./
         with:
           api-url: https://app.dev.codecargo.dev
-          default-action: deny
-          allowed-hosts:
-            app.dev.codecargo.dev,
+          allowed-hosts: |
+            app.dev.codecargo.dev
             github.com
           fail-on-unsupported: false
 
@@ -145,14 +141,13 @@ jobs:
         uses: ./
         with:
           api-url: https://app.dev.codecargo.dev
-          default-action: deny
           allowed-hosts: |
-            github.com,
-            app.dev.codecargo.dev,
-            docker.io,
-            docker.com,
-            registry-1.docker.io,
-            auth.docker.io,
+            github.com
+            app.dev.codecargo.dev
+            docker.io
+            docker.com
+            registry-1.docker.io
+            auth.docker.io
             production.cloudflare.docker.com
 
       - name: Test Docker pull (should work)
@@ -181,12 +176,10 @@ jobs:
         uses: ./
         with:
           api-url: https://app.dev.codecargo.dev
-          default-action: deny
           allowed-hosts: |
-            app.dev.codecargo.dev,
-            github.com,
-            archive.ubuntu.com,
-            security.ubuntu.com
+            app.dev.codecargo.dev
+            github.com
+            archive.ubuntu.com
             security.ubuntu.com
           sudo-lockdown: true
           sudo-allow-commands: /usr/bin/apt-get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,10 +100,10 @@ jobs:
         uses: ./
         with:
           api-url: https://app.dev.codecargo.dev
-          allowed-cidrs: "140.82.112.0/20"  # GitHub's IP range
-          allowed-hosts:
+          allowed-cidrs: |
+            "140.82.112.0/20"  # GitHub's IP range
+          allowed-hosts: |
             app.dev.codecargo.dev
-            github.com
 
       - name: Test connection to allowed CIDR
         run: |

--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ For concepts, architecture, and platform capabilities, see the [main CargoWall r
 ## Quick Start
 
 ```yaml
-- uses: code-cargo/cargowall@v1
+- uses: code-cargo/cargowall-action@v1
   with:
-    default-action: deny
     allowed-hosts: |
-      github.com,
-      githubusercontent.com,
+      github.com
+      githubusercontent.com
       registry.npmjs.org
 ```
 
@@ -52,13 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: code-cargo/cargowall@v1
+      - uses: code-cargo/cargowall-action@v1
         with:
-          default-action: deny
           allowed-hosts: |
-            github.com,
-            githubusercontent.com,
-            api.github.com,
+            githubusercontent.com
             registry.npmjs.org
 
       - run: npm ci
@@ -73,12 +69,11 @@ jobs:
 CargoWall automatically configures Docker to use its DNS proxy, so hostname filtering works inside containers:
 
 ```yaml
-- uses: code-cargo/cargowall@v1
+- uses: code-cargo/cargowall-action@v1
   with:
-    default-action: deny
     allowed-hosts: |
-      docker.io,
-      docker.com,
+      docker.io
+      docker.com
       registry.npmjs.org
 
 - name: Build Docker image
@@ -90,12 +85,10 @@ CargoWall automatically configures Docker to use its DNS proxy, so hostname filt
 Run in audit mode to log connections without blocking them — useful for understanding your workflow's network dependencies before enforcing rules:
 
 ```yaml
-- uses: code-cargo/cargowall@v1
+- uses: code-cargo/cargowall-action@v1
   with:
     mode: audit
-    default-action: deny
     allowed-hosts: |
-      github.com,
       githubusercontent.com
 ```
 
@@ -104,14 +97,14 @@ Run in audit mode to log connections without blocking them — useful for unders
 Enable sudo lockdown to prevent subsequent steps from disabling the firewall:
 
 ```yaml
-- uses: code-cargo/cargowall@v1
+- uses: code-cargo/cargowall-action@v1
   with:
-    default-action: deny
     allowed-hosts: |
-      github.com,
       archive.ubuntu.com
     sudo-lockdown: true
-    sudo-allow-commands: /usr/bin/apt-get,/usr/bin/docker
+    sudo-allow-commands: |
+      /usr/bin/apt-get
+      /usr/bin/docker
 ```
 
 ### With Config File
@@ -119,7 +112,7 @@ Enable sudo lockdown to prevent subsequent steps from disabling the firewall:
 For complex configurations, use a JSON or YAML config file:
 
 ```yaml
-- uses: code-cargo/cargowall@v1
+- uses: code-cargo/cargowall-action@v1
   with:
     config-file: .github/cargowall.json
 ```
@@ -127,7 +120,6 @@ For complex configurations, use a JSON or YAML config file:
 **`.github/cargowall.json`**:
 ```json
 {
-  "defaultAction": "deny",
   "rules": [
     { "type": "hostname", "value": "github.com", "action": "allow" },
     { "type": "hostname", "value": "registry.npmjs.org", "action": "allow" },
@@ -138,28 +130,27 @@ For complex configurations, use a JSON or YAML config file:
 
 ## Inputs
 
-| Input                        | Description                                                          | Default      |
-|------------------------------|----------------------------------------------------------------------|--------------|
-| `mode`                       | Enforcement mode: `enforce` (block) or `audit` (log only)           | `enforce`    |
-| `default-action`             | Default action for unmatched traffic (`allow` or `deny`)             | `deny`       |
-| `allowed-hosts`              | Comma-separated allowed hostnames (supports wildcards)               |              |
-| `allowed-cidrs`              | Comma-separated allowed CIDR blocks                                  |              |
-| `blocked-hosts`              | Comma-separated blocked hostnames                                    |              |
-| `blocked-cidrs`              | Comma-separated blocked CIDR blocks                                  |              |
-| `config-file`                | Path to YAML/JSON config file for advanced rules                     |              |
-| `version`                    | CargoWall version to use                                             | `latest`     |
-| `fail-on-unsupported`        | Fail if eBPF not supported                                          | `false`      |
-| `sudo-lockdown`              | Enable sudo lockdown to prevent firewall bypass                      | `false`      |
-| `sudo-allow-commands`        | Comma-separated command paths to allow via sudo when locked          |              |
-| `dns-upstream`               | Upstream DNS server (auto-detected if not set)                       | auto-detect  |
-| `allow-existing-connections` | Allow pre-existing TCP connections at startup                        | `true`       |
-| `binary-path`                | Path to a pre-built cargowall binary (skips download)                |              |
-| `debug`                      | Enable debug logging                                                 | `false`      |
-| `audit-summary`              | Generate audit summary in workflow summary                           | `true`       |
-| `github-token`               | GitHub token for downloading the binary and fetching step timing in audit summary | `${{ github.token }}` |
-| `include-prerelease`         | Include pre-release versions when resolving "latest"                 | `false`      |
-| `api-url`                    | CodeCargo API URL to push audit results to                           |              |
-| `api-audience`               | OIDC audience for CodeCargo API authentication                       | `codecargo`  |
+| Input                        | Description                                                                       | Default                    |
+|------------------------------|-----------------------------------------------------------------------------------|----------------------------|
+| `mode`                       | Enforcement mode: `enforce` (block) or `audit` (log only)                         | `enforce`                  |
+| `allowed-hosts`              | Allowed hostnames, one per line (auto matches subdomains)                         |                            |
+| `allowed-cidrs`              | Allowed CIDR blocks, one per line                                                 |                            |
+| `github-service-hosts`       | GitHub service hostnames to auto-allow on port 443 (one per line)                 | See [defaults](#automatically-allowed-traffic) |
+| `azure-infra-hosts`          | Azure infrastructure hostnames to auto-allow on port 443 (one per line)           | See [defaults](#automatically-allowed-traffic) |
+| `config-file`                | Path to YAML/JSON config file for advanced rules                                  |                            |
+| `version`                    | CargoWall version to use                                                          | `latest`                   |
+| `fail-on-unsupported`        | Fail if eBPF not supported                                                        | `false`                    |
+| `sudo-lockdown`              | Enable sudo lockdown to prevent firewall bypass                                   | `false`                    |
+| `sudo-allow-commands`        | Command paths to allow via sudo when locked, one per line                         |                            |
+| `dns-upstream`               | Upstream DNS server (auto-detected if not set)                                    | auto-detect                |
+| `allow-existing-connections` | Allow pre-existing TCP connections at startup                                     | `true`                     |
+| `binary-path`                | Path to a pre-built cargowall binary (skips download)                             |                            |
+| `debug`                      | Enable debug logging                                                              | `false`                    |
+| `audit-summary`              | Generate audit summary in workflow summary                                        | `true`                     |
+| `github-token`               | GitHub token for downloading the binary and fetching step timing in audit summary | `${{ github.token }}`      |
+| `include-prerelease`         | Include pre-release versions when resolving "latest"                              | `false`                    |
+| `api-url`                    | CodeCargo API URL to push audit results to                                        |                            |
+| `api-audience`               | OIDC audience for CodeCargo API authentication                                    | `codecargo`                |
 
 ## Outputs
 
@@ -213,7 +204,9 @@ flowchart LR
 
 #### Automatically Allowed Traffic
 
-CargoWall automatically allows certain traffic required for the runner and GitHub Actions to function:
+CargoWall automatically allows certain traffic required for the runner and GitHub Actions to function.
+
+**Infrastructure (hardcoded):**
 
 | Traffic                             | Ports         | Why                                        |
 |-------------------------------------|---------------|--------------------------------------------|
@@ -222,13 +215,29 @@ CargoWall automatically allows certain traffic required for the runner and GitHu
 | DNS upstream server                 | 53            | Required for DNS resolution                |
 | systemd-resolved upstreams          | 53, 80, 32526 | Runner DNS infrastructure                  |
 | Docker bridge IP                    | 53            | DNS for containers                         |
-| `actions.githubusercontent.com`     | All           | GitHub Actions artifact/cache services     |
-| `ACTIONS_RUNTIME_URL` host          | All           | GitHub Actions runtime                     |
-| `ACTIONS_RESULTS_URL` host          | All           | GitHub Actions results                     |
-| `ACTIONS_CACHE_URL` host            | All           | GitHub Actions cache                       |
-| `ACTIONS_ID_TOKEN_REQUEST_URL` host | All           | GitHub Actions OIDC token requests         |
+| `ACTIONS_RUNTIME_URL` host          | 443           | GitHub Actions runtime                     |
+| `ACTIONS_RESULTS_URL` host          | 443           | GitHub Actions results                     |
+| `ACTIONS_CACHE_URL` host            | 443           | GitHub Actions cache                       |
+| `ACTIONS_ID_TOKEN_REQUEST_URL` host | 443           | GitHub Actions OIDC token requests         |
 | IPv6 multicast (ff00::/8)           | All           | Neighbor discovery, required for IPv6      |
 | ICMPv6                              | All           | IPv6 neighbor discovery protocol           |
+
+**GitHub service hostnames** (configurable via `github-service-hosts`):
+
+| Hostname                            | Ports | Why                                    |
+|-------------------------------------|-------|----------------------------------------|
+| `github.com`                        | 443   | Git operations, API                    |
+| `api.github.com`                    | 443   | GitHub REST/GraphQL API                |
+| `githubapp.com`                     | 443   | GitHub Apps infrastructure             |
+| `actions.githubusercontent.com`     | 443   | Actions artifact/cache/log services    |
+| `github.githubassets.com`           | 443   | GitHub static assets                   |
+
+**Azure infrastructure hostnames** (configurable via `azure-infra-hosts`):
+
+| Hostname                            | Ports | Why                                    |
+|-------------------------------------|-------|----------------------------------------|
+| `trafficmanager.net`                | 443   | Azure Traffic Manager (DNS routing)    |
+| `blob.core.windows.net`            | 443   | Azure Blob Storage (Actions artifacts) |
 
 ### Sudo Lockdown
 
@@ -236,7 +245,9 @@ When `sudo-lockdown: true`, sudo is restricted so that subsequent workflow steps
 
 ```yaml
 sudo-lockdown: true
-sudo-allow-commands: /usr/bin/apt-get,/usr/bin/docker
+sudo-allow-commands: |
+  /usr/bin/apt-get
+  /usr/bin/docker
 ```
 
 With this configuration, `sudo apt-get install ...` and `sudo docker build ...` will work, but attempts to run `sudo iptables -F`, `sudo pkill cargowall`, or `sudo vim /etc/resolv.conf` will be blocked.

--- a/action.yml
+++ b/action.yml
@@ -11,21 +11,27 @@ inputs:
     description: 'Enforcement mode: "enforce" (block connections) or "audit" (log only, no blocking)'
     required: false
     default: 'enforce'
-  default-action:
-    description: 'Default action for unmatched traffic (allow or deny)'
-    default: 'deny'
   allowed-hosts:
-    description: 'Comma-separated allowed hostnames (supports wildcards like *.github.com)'
+    description: 'Allowed hostnames, one per line (auto matches subdomains example.com would also match api.example.com)'
     required: false
   allowed-cidrs:
-    description: 'Comma-separated allowed CIDR blocks'
+    description: 'Allowed CIDR blocks, one per line'
     required: false
-  blocked-hosts:
-    description: 'Comma-separated blocked hostnames'
+  github-service-hosts:
+    description: 'GitHub service hostnames to auto-allow on port 443 (one per line)'
     required: false
-  blocked-cidrs:
-    description: 'Comma-separated blocked CIDR blocks'
+    default: |
+      github.com
+      api.github.com
+      githubapp.com
+      actions.githubusercontent.com
+      github.githubassets.com
+  azure-infra-hosts:
+    description: 'Azure infrastructure hostnames to auto-allow on port 443 (one per line)'
     required: false
+    default: |
+      trafficmanager.net
+      blob.core.windows.net
   config-file:
     description: 'Path to YAML/JSON config file for advanced rules'
     required: false
@@ -42,7 +48,7 @@ inputs:
     description: 'Enable sudo lockdown to prevent firewall bypass'
     default: 'false'
   sudo-allow-commands:
-    description: 'Comma-separated list of command paths to allow via sudo when lockdown is enabled (e.g. /usr/bin/apt-get,/usr/bin/docker)'
+    description: 'Command paths to allow via sudo when lockdown is enabled, one per line (e.g. /usr/bin/apt-get)'
     default: ''
   dns-upstream:
     description: 'Upstream DNS server for forwarding queries (auto-detected from /etc/resolv.conf if not set)'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -23384,6 +23384,13 @@ function getInput(name, options) {
   }
   return val.trim();
 }
+function getMultilineInput(name, options) {
+  const inputs = getInput(name, options).split("\n").filter((x) => x !== "");
+  if (options && options.trimWhitespace === false) {
+    return inputs;
+  }
+  return inputs.map((input) => input.trim());
+}
 function setOutput(name, value) {
   const filePath = process.env["GITHUB_OUTPUT"] || "";
   if (filePath) {
@@ -27700,7 +27707,6 @@ var STARTUP_TIMEOUT = 30;
 var STEP_PLAN_FILE = "/tmp/cargowall-step-plan.json";
 var STEP_TIMESTAMPS_FILE = "/tmp/cargowall-step-timestamps.jsonl";
 var VALID_MODES = ["enforce", "audit"];
-var VALID_ACTIONS = ["allow", "deny"];
 async function showLastLog() {
   try {
     let logOutput = "";
@@ -27718,18 +27724,15 @@ ${logOutput}`);
   }
 }
 async function start() {
-  const mode = getInput("mode") || "enforce";
-  const defaultAction = getInput("default-action") || "deny";
+  let mode = getInput("mode") || "enforce";
   if (!VALID_MODES.includes(mode)) {
     warning(`Invalid mode "${mode}" \u2014 expected "enforce" or "audit". Defaulting to "enforce".`);
+    mode = "enforce";
   }
-  if (!VALID_ACTIONS.includes(defaultAction)) {
-    warning(`Invalid default-action "${defaultAction}" \u2014 expected "allow" or "deny". Defaulting to "deny".`);
-  }
-  const allowedHosts = getInput("allowed-hosts");
-  const allowedCidrs = getInput("allowed-cidrs");
-  const blockedHosts = getInput("blocked-hosts");
-  const blockedCidrs = getInput("blocked-cidrs");
+  const allowedHosts = parseList(getMultilineInput("allowed-hosts"));
+  const allowedCidrs = parseList(getMultilineInput("allowed-cidrs"));
+  const githubServiceHosts = parseList(getMultilineInput("github-service-hosts"));
+  const azureInfraHosts = parseList(getMultilineInput("azure-infra-hosts"));
   const configFile = getInput("config-file");
   const sudoLockdown = getInput("sudo-lockdown") === "true";
   const debug2 = getInput("debug") === "true";
@@ -27752,7 +27755,7 @@ async function start() {
   }
   if (sudoLockdown) {
     args.push("--sudo-lockdown");
-    const sudoAllowCommands = getInput("sudo-allow-commands");
+    const sudoAllowCommands = parseList(getMultilineInput("sudo-allow-commands"));
     if (sudoAllowCommands) {
       args.push(`--sudo-allow-commands=${sudoAllowCommands}`);
     }
@@ -27781,11 +27784,10 @@ async function start() {
   }
   info("Configuration:");
   info(`  Mode: ${mode}`);
-  info(`  Default action: ${defaultAction}`);
   if (allowedHosts) info(`  Allowed hosts: ${allowedHosts}`);
   if (allowedCidrs) info(`  Allowed CIDRs: ${allowedCidrs}`);
-  if (blockedHosts) info(`  Blocked hosts: ${blockedHosts}`);
-  if (blockedCidrs) info(`  Blocked CIDRs: ${blockedCidrs}`);
+  if (githubServiceHosts) info(`  GitHub service hosts: ${githubServiceHosts}`);
+  if (azureInfraHosts) info(`  Azure infra hosts: ${azureInfraHosts}`);
   if (configFile) info(`  Config file: ${configFile}`);
   info(`  Sudo lockdown: ${sudoLockdown}`);
   info(`  DNS upstream: ${dnsUpstream}`);
@@ -27805,11 +27807,11 @@ async function start() {
   info("Starting cargowall...");
   const env = {
     ...process.env,
-    CARGOWALL_DEFAULT_ACTION: defaultAction,
-    CARGOWALL_ALLOWED_HOSTS: allowedHosts,
-    CARGOWALL_ALLOWED_CIDRS: allowedCidrs,
-    CARGOWALL_BLOCKED_HOSTS: blockedHosts,
-    CARGOWALL_BLOCKED_CIDRS: blockedCidrs
+    CARGOWALL_DEFAULT_ACTION: "deny",
+    ...allowedHosts && { CARGOWALL_ALLOWED_HOSTS: allowedHosts },
+    ...allowedCidrs && { CARGOWALL_ALLOWED_CIDRS: allowedCidrs },
+    ...githubServiceHosts && { CARGOWALL_GITHUB_SERVICE_HOSTS: githubServiceHosts },
+    ...azureInfraHosts && { CARGOWALL_AZURE_INFRA_HOSTS: azureInfraHosts }
   };
   const logFd = (0, import_fs7.openSync)(CARGOWALL_LOG, "w");
   const child2 = (0, import_child_process.spawn)("sudo", ["-E", "cargowall", ...args], {
@@ -27912,6 +27914,9 @@ async function restoreDns() {
     await exec("sudo", ["cp", RESOLV_CONF_BACKUP, "/etc/resolv.conf"]);
   } catch {
   }
+}
+function parseList(lines) {
+  return lines.flatMap((line) => line.split(",")).map((entry) => entry.trim()).filter(Boolean).join(",");
 }
 function sleep(ms) {
   return new Promise((resolve2) => setTimeout(resolve2, ms));

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -25303,7 +25303,7 @@ ${watcherLog.trimEnd()}`);
       } catch {
       }
       summaryArgs.push("--mode", effectiveMode);
-      summaryArgs.push("--default-action", getInput("default-action") || "deny");
+      summaryArgs.push("--default-action", "deny");
       summaryArgs.push("--job-status", jobStatus);
       try {
         const audience = getInput("api-audience") || "codecargo";

--- a/examples/advanced.yml
+++ b/examples/advanced.yml
@@ -32,15 +32,14 @@ jobs:
       # so hostname filtering works inside containers
       - uses: code-cargo/cargowall-action@v1
         with:
-          default-action: deny
           allowed-hosts: |
-            docker.io,
-            *.docker.com,
-            registry-1.docker.io,
-            auth.docker.io,
-            production.cloudflare.docker.com,
-            ghcr.io,
-            *.pkg.github.com,
+            docker.io
+            docker.com
+            registry-1.docker.io
+            auth.docker.io
+            production.cloudflare.docker.com
+            ghcr.io
+            pkg.github.com
             registry.npmjs.org
 
       # Docker builds work with hostname filtering
@@ -76,13 +75,10 @@ jobs:
       # Self-hosted runners have full eBPF support
       - uses: code-cargo/cargowall-action@v1
         with:
-          default-action: deny
           allowed-hosts: |
-            github.com,
-            *.githubusercontent.com,
             internal-registry.company.com
           allowed-cidrs: |
-            10.0.0.0/8,
+            10.0.0.0/8
             192.168.0.0/16
           fail-on-unsupported: true
 

--- a/examples/basic.yml
+++ b/examples/basic.yml
@@ -14,13 +14,9 @@ jobs:
       # Enable network egress filtering
       - uses: code-cargo/cargowall-action@v1
         with:
-          default-action: deny
           allowed-hosts: |
-            github.com,
-            *.githubusercontent.com,
-            api.github.com,
-            registry.npmjs.org,
-            *.cloudflare.com
+            registry.npmjs.org
+            cloudflare.com
 
       # Your build steps - only allowed hosts can be reached
       - name: Setup Node.js

--- a/examples/secure.yml
+++ b/examples/secure.yml
@@ -15,16 +15,14 @@ jobs:
       # subsequent steps from disabling the firewall
       - uses: code-cargo/cargowall-action@v1
         with:
-          default-action: deny
           allowed-hosts: |
-            github.com,
-            *.githubusercontent.com,
-            api.github.com,
-            registry.npmjs.org,
-            archive.ubuntu.com,
+            registry.npmjs.org
+            archive.ubuntu.com
             security.ubuntu.com
           sudo-lockdown: true
-          sudo-allow-commands: /usr/bin/apt-get,/usr/bin/docker
+          sudo-allow-commands: |
+            /usr/bin/apt-get
+            /usr/bin/docker
 
       # Package installation works via allowed commands
       - name: Install system dependencies
@@ -59,7 +57,6 @@ jobs:
 
       - uses: code-cargo/cargowall-action@v1
         with:
-          default-action: deny
           allowed-hosts: "github.com"
           sudo-lockdown: true
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -17,7 +17,6 @@ const STEP_PLAN_FILE = '/tmp/cargowall-step-plan.json'
 const STEP_TIMESTAMPS_FILE = '/tmp/cargowall-step-timestamps.jsonl'
 
 const VALID_MODES = ['enforce', 'audit'] as const
-const VALID_ACTIONS = ['allow', 'deny'] as const
 
 async function showLastLog(): Promise<void> {
   try {
@@ -33,19 +32,17 @@ async function showLastLog(): Promise<void> {
 }
 
 export async function start(): Promise<{ supported: boolean; pid: number | null }> {
-  const mode = core.getInput('mode') || 'enforce'
-  const defaultAction = core.getInput('default-action') || 'deny'
+  let mode = core.getInput('mode') || 'enforce'
 
   if (!VALID_MODES.includes(mode as typeof VALID_MODES[number])) {
     core.warning(`Invalid mode "${mode}" — expected "enforce" or "audit". Defaulting to "enforce".`)
+    mode = 'enforce'
   }
-  if (!VALID_ACTIONS.includes(defaultAction as typeof VALID_ACTIONS[number])) {
-    core.warning(`Invalid default-action "${defaultAction}" — expected "allow" or "deny". Defaulting to "deny".`)
-  }
-  const allowedHosts = core.getInput('allowed-hosts')
-  const allowedCidrs = core.getInput('allowed-cidrs')
-  const blockedHosts = core.getInput('blocked-hosts')
-  const blockedCidrs = core.getInput('blocked-cidrs')
+  const allowedHosts = parseList(core.getMultilineInput('allowed-hosts'))
+  const allowedCidrs = parseList(core.getMultilineInput('allowed-cidrs'))
+  const githubServiceHosts = parseList(core.getMultilineInput('github-service-hosts'))
+  const azureInfraHosts = parseList(core.getMultilineInput('azure-infra-hosts'))
+
   const configFile = core.getInput('config-file')
   const sudoLockdown = core.getInput('sudo-lockdown') === 'true'
   const debug = core.getInput('debug') === 'true'
@@ -77,7 +74,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
 
   if (sudoLockdown) {
     args.push('--sudo-lockdown')
-    const sudoAllowCommands = core.getInput('sudo-allow-commands')
+    const sudoAllowCommands = parseList(core.getMultilineInput('sudo-allow-commands'))
     if (sudoAllowCommands) {
       args.push(`--sudo-allow-commands=${sudoAllowCommands}`)
     }
@@ -114,11 +111,10 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   // Log configuration
   core.info('Configuration:')
   core.info(`  Mode: ${mode}`)
-  core.info(`  Default action: ${defaultAction}`)
   if (allowedHosts) core.info(`  Allowed hosts: ${allowedHosts}`)
   if (allowedCidrs) core.info(`  Allowed CIDRs: ${allowedCidrs}`)
-  if (blockedHosts) core.info(`  Blocked hosts: ${blockedHosts}`)
-  if (blockedCidrs) core.info(`  Blocked CIDRs: ${blockedCidrs}`)
+  if (githubServiceHosts) core.info(`  GitHub service hosts: ${githubServiceHosts}`)
+  if (azureInfraHosts) core.info(`  Azure infra hosts: ${azureInfraHosts}`)
   if (configFile) core.info(`  Config file: ${configFile}`)
   core.info(`  Sudo lockdown: ${sudoLockdown}`)
   core.info(`  DNS upstream: ${dnsUpstream}`)
@@ -147,11 +143,11 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   // Set environment variables for cargowall
   const env = {
     ...process.env,
-    CARGOWALL_DEFAULT_ACTION: defaultAction,
-    CARGOWALL_ALLOWED_HOSTS: allowedHosts,
-    CARGOWALL_ALLOWED_CIDRS: allowedCidrs,
-    CARGOWALL_BLOCKED_HOSTS: blockedHosts,
-    CARGOWALL_BLOCKED_CIDRS: blockedCidrs,
+    CARGOWALL_DEFAULT_ACTION: 'deny',
+    ...(allowedHosts && { CARGOWALL_ALLOWED_HOSTS: allowedHosts }),
+    ...(allowedCidrs && { CARGOWALL_ALLOWED_CIDRS: allowedCidrs }),
+    ...(githubServiceHosts && { CARGOWALL_GITHUB_SERVICE_HOSTS: githubServiceHosts }),
+    ...(azureInfraHosts && { CARGOWALL_AZURE_INFRA_HOSTS: azureInfraHosts }),
   }
 
   const logFd = openSync(CARGOWALL_LOG, 'w')
@@ -291,6 +287,15 @@ async function restoreDns(): Promise<void> {
   } catch {
     // No backup to restore
   }
+}
+
+/** Split on both newlines (handled by getMultilineInput) and commas, trim, drop empties. */
+function parseList(lines: string[]): string {
+  return lines
+    .flatMap(line => line.split(','))
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .join(',')
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -166,7 +166,7 @@ export async function generateSummary(): Promise<void> {
         // State file not present — use Action input as fallback
       }
       summaryArgs.push('--mode', effectiveMode)
-      summaryArgs.push('--default-action', core.getInput('default-action') || 'deny')
+      summaryArgs.push('--default-action', 'deny')
       summaryArgs.push('--job-status', jobStatus)
 
       // Get OIDC token for API authentication


### PR DESCRIPTION
Closes #24 

Related to code-cargo/cargowall#21

- Changes lists from comma separated to multi-line inputs
- Removes concept of default allow with blocking hosts/cidrs
- Adds default allows for GitHub and Azure services 