### PR TITLE
#26 update api url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,8 @@ jobs:
       - name: Setup CargoWall with strict hosts
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
-            app.dev.codecargo.dev
+            app.codecargo.com
             github.com
             api.github.com
 
@@ -99,11 +98,10 @@ jobs:
       - name: Setup CargoWall with CIDR rules
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-cidrs: |
             "140.82.112.0/20"  # GitHub's IP range
           allowed-hosts: |
-            app.dev.codecargo.dev
+            app.codecargo.com
 
       - name: Test connection to allowed CIDR
         run: |
@@ -121,9 +119,8 @@ jobs:
         id: cargowall
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
-            app.dev.codecargo.dev
+            app.codecargo.com
             github.com
           fail-on-unsupported: false
 
@@ -140,10 +137,9 @@ jobs:
       - name: Setup CargoWall
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             github.com
-            app.dev.codecargo.dev
+            app.codecargo.com
             docker.io
             docker.com
             registry-1.docker.io
@@ -175,9 +171,8 @@ jobs:
       - name: Setup CargoWall with sudo lockdown
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
-            app.dev.codecargo.dev
+            app.codecargo.com
             github.com
             archive.ubuntu.com
             security.ubuntu.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup CargoWall
         uses: ./
         with:
+          offline: 'true'
           allowed-hosts: |
             github.com
             githubusercontent.com

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ For complex configurations, use a JSON or YAML config file:
 | `audit-summary`              | Generate audit summary in workflow summary                                        | `true`                                         |
 | `github-token`               | GitHub token for downloading the binary and fetching step timing in audit summary | `${{ github.token }}`                          |
 | `include-prerelease`         | Include pre-release versions when resolving "latest"                              | `false`                                        |
-| `api-url`                    | CodeCargo API URL to push audit results to                                        | `https://app.codecargo.com`                    |
-| `offline`                    | Skip CodeCargo API communication entirely                                         | `false`                                        |
+| `api-url`                    | CodeCargo API URL for audit upload and policy fetch (policy requires GitHub App)   | `https://app.codecargo.com`                    |
+| `offline`                    | Skip all CodeCargo API communication (audit upload and policy fetch)              | `false`                                        |
 | `api-audience`               | OIDC audience for CodeCargo API authentication                                    | `codecargo`                                    |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CargoWall GitHub Action
 
+> ⚠️ **Warning:** The CodeCargo API is under active development and not yet finalized. Breaking changes may occur. Set `offline: true` to disable API communication if you don't need platform integration.
+
 [![CI](https://github.com/code-cargo/cargowall-action/actions/workflows/test.yml/badge.svg)](https://github.com/code-cargo/cargowall-action/actions/workflows/test.yml)
 [![Check dist](https://github.com/code-cargo/cargowall-action/actions/workflows/check-dist.yml/badge.svg)](https://github.com/code-cargo/cargowall-action/actions/workflows/check-dist.yml)
 [![License](https://img.shields.io/github/license/code-cargo/cargowall-action)](LICENSE)
@@ -48,6 +50,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -62,7 +65,7 @@ jobs:
       - run: npm test
 ```
 
-> **Note:** To connect to the [CodeCargo platform](https://www.codecargo.com) via `api-url`, your job needs these minimum permissions: `id-token: write` (OIDC authentication), `actions: read` (correlate network events to steps), and `contents: read`.
+> **Note:** The action connects to the [CodeCargo platform](https://www.codecargo.com) by default. For full integration, your job needs these permissions: `id-token: write` (OIDC authentication), `actions: read` (correlate network events to steps), and `contents: read`. If `id-token: write` is not granted, the action will warn and continue without API integration. Set `offline: true` to skip API communication entirely.
 
 ### With Docker Support
 
@@ -130,27 +133,28 @@ For complex configurations, use a JSON or YAML config file:
 
 ## Inputs
 
-| Input                        | Description                                                                       | Default                    |
-|------------------------------|-----------------------------------------------------------------------------------|----------------------------|
-| `mode`                       | Enforcement mode: `enforce` (block) or `audit` (log only)                         | `enforce`                  |
-| `allowed-hosts`              | Allowed hostnames, one per line (auto matches subdomains)                         |                            |
-| `allowed-cidrs`              | Allowed CIDR blocks, one per line                                                 |                            |
+| Input                        | Description                                                                       | Default                                        |
+|------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------|
+| `mode`                       | Enforcement mode: `enforce` (block) or `audit` (log only)                         | `enforce`                                      |
+| `allowed-hosts`              | Allowed hostnames, one per line (auto matches subdomains)                         |                                                |
+| `allowed-cidrs`              | Allowed CIDR blocks, one per line                                                 |                                                |
 | `github-service-hosts`       | GitHub service hostnames to auto-allow on port 443 (one per line)                 | See [defaults](#automatically-allowed-traffic) |
 | `azure-infra-hosts`          | Azure infrastructure hostnames to auto-allow on port 443 (one per line)           | See [defaults](#automatically-allowed-traffic) |
-| `config-file`                | Path to YAML/JSON config file for advanced rules                                  |                            |
-| `version`                    | CargoWall version to use                                                          | `latest`                   |
-| `fail-on-unsupported`        | Fail if eBPF not supported                                                        | `false`                    |
-| `sudo-lockdown`              | Enable sudo lockdown to prevent firewall bypass                                   | `false`                    |
-| `sudo-allow-commands`        | Command paths to allow via sudo when locked, one per line                         |                            |
-| `dns-upstream`               | Upstream DNS server (auto-detected if not set)                                    | auto-detect                |
-| `allow-existing-connections` | Allow pre-existing TCP connections at startup                                     | `true`                     |
-| `binary-path`                | Path to a pre-built cargowall binary (skips download)                             |                            |
-| `debug`                      | Enable debug logging                                                              | `false`                    |
-| `audit-summary`              | Generate audit summary in workflow summary                                        | `true`                     |
-| `github-token`               | GitHub token for downloading the binary and fetching step timing in audit summary | `${{ github.token }}`      |
-| `include-prerelease`         | Include pre-release versions when resolving "latest"                              | `false`                    |
-| `api-url`                    | CodeCargo API URL to push audit results to                                        |                            |
-| `api-audience`               | OIDC audience for CodeCargo API authentication                                    | `codecargo`                |
+| `config-file`                | Path to YAML/JSON config file for advanced rules                                  |                                                |
+| `version`                    | CargoWall version to use                                                          | `latest`                                       |
+| `fail-on-unsupported`        | Fail if eBPF not supported                                                        | `false`                                        |
+| `sudo-lockdown`              | Enable sudo lockdown to prevent firewall bypass                                   | `false`                                        |
+| `sudo-allow-commands`        | Command paths to allow via sudo when locked, one per line                         |                                                |
+| `dns-upstream`               | Upstream DNS server (auto-detected if not set)                                    | auto-detect                                    |
+| `allow-existing-connections` | Allow pre-existing TCP connections at startup                                     | `true`                                         |
+| `binary-path`                | Path to a pre-built cargowall binary (skips download)                             |                                                |
+| `debug`                      | Enable debug logging                                                              | `false`                                        |
+| `audit-summary`              | Generate audit summary in workflow summary                                        | `true`                                         |
+| `github-token`               | GitHub token for downloading the binary and fetching step timing in audit summary | `${{ github.token }}`                          |
+| `include-prerelease`         | Include pre-release versions when resolving "latest"                              | `false`                                        |
+| `api-url`                    | CodeCargo API URL to push audit results to                                        | `https://app.codecargo.com`                    |
+| `offline`                    | Skip CodeCargo API communication entirely                                         | `false`                                        |
+| `api-audience`               | OIDC audience for CodeCargo API authentication                                    | `codecargo`                                    |
 
 ## Outputs
 
@@ -234,10 +238,10 @@ CargoWall automatically allows certain traffic required for the runner and GitHu
 
 **Azure infrastructure hostnames** (configurable via `azure-infra-hosts`):
 
-| Hostname                            | Ports | Why                                    |
-|-------------------------------------|-------|----------------------------------------|
-| `trafficmanager.net`                | 443   | Azure Traffic Manager (DNS routing)    |
-| `blob.core.windows.net`            | 443   | Azure Blob Storage (Actions artifacts) |
+| Hostname                | Ports | Why                                    |
+|-------------------------|-------|----------------------------------------|
+| `trafficmanager.net`    | 443   | Azure Traffic Manager (DNS routing)    |
+| `blob.core.windows.net` | 443   | Azure Blob Storage (Actions artifacts) |
 
 ### Sudo Lockdown
 

--- a/action.yml
+++ b/action.yml
@@ -69,8 +69,12 @@ inputs:
     description: 'GitHub token for downloading the binary and fetching step timing in audit summary'
     default: ${{ github.token }}
   api-url:
-    description: 'CodeCargo API URL to push audit results to (e.g. https://app.codecargo.com). Requires permissions: id-token: write'
+    description: 'CodeCargo API URL to push audit results to. Requires permissions: id-token: write'
     required: false
+    default: 'https://app.codecargo.com'
+  offline:
+    description: 'Skip CodeCargo API communication entirely (no policy fetch or audit push)'
+    default: 'false'
   api-audience:
     description: 'OIDC audience for CodeCargo API authentication'
     default: 'codecargo'

--- a/action.yml
+++ b/action.yml
@@ -69,11 +69,11 @@ inputs:
     description: 'GitHub token for downloading the binary and fetching step timing in audit summary'
     default: ${{ github.token }}
   api-url:
-    description: 'CodeCargo API URL to push audit results to. Requires permissions: id-token: write'
+    description: 'CodeCargo API URL for audit upload and policy fetch (policy requires CodeCargo GitHub App installation). Requires permissions: id-token: write'
     required: false
     default: 'https://app.codecargo.com'
   offline:
-    description: 'Skip CodeCargo API communication entirely (no policy fetch or audit push)'
+    description: 'Skip all CodeCargo API communication (audit upload and policy fetch)'
     default: 'false'
   api-audience:
     description: 'OIDC audience for CodeCargo API authentication'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -27763,8 +27763,9 @@ async function start() {
   if (allowExistingConnections) {
     args.push("--allow-existing-connections");
   }
+  const offline = getInput("offline") === "true";
   const apiUrl = getInput("api-url");
-  if (apiUrl) {
+  if (apiUrl && !offline) {
     args.push(`--api-url=${apiUrl}`);
     args.push(`--job-key=${context2.job}`);
     try {

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -25291,8 +25291,9 @@ ${watcherLog.trimEnd()}`);
       }
     }
     const summaryArgs = ["summary", "--audit-log", AUDIT_LOG, "--steps", stepsJson];
+    const offline = getInput("offline") === "true";
     const apiUrl = getInput("api-url");
-    if (apiUrl) {
+    if (apiUrl && !offline) {
       summaryArgs.push("--api-url", apiUrl);
       summaryArgs.push("--job-key", context2.job);
       summaryArgs.push("--job-name", currentJobName || context2.job);
@@ -25313,6 +25314,10 @@ ${watcherLog.trimEnd()}`);
         warning(
           `Failed to get OIDC token for API push. Ensure the workflow has "permissions: id-token: write". Error: ${error}`
         );
+        for (const flag of ["--api-url", "--job-key", "--job-name", "--mode", "--default-action", "--job-status"]) {
+          const idx = summaryArgs.findIndex((a) => a === flag);
+          if (idx !== -1) summaryArgs.splice(idx, 2);
+        }
       }
     }
     let summaryOutput = "";

--- a/src/start.ts
+++ b/src/start.ts
@@ -84,10 +84,12 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
     args.push('--allow-existing-connections')
   }
 
-  // When api-url is configured, fetch OIDC token and pass API flags so the
-  // Go binary can fetch the resolved policy from the CodeCargo SaaS API.
+  // When api-url is configured and offline mode is not enabled, fetch OIDC
+  // token and pass API flags so the Go binary can fetch the resolved policy
+  // from the CodeCargo SaaS API.
+  const offline = core.getInput('offline') === 'true'
   const apiUrl = core.getInput('api-url')
-  if (apiUrl) {
+  if (apiUrl && !offline) {
     args.push(`--api-url=${apiUrl}`)
     args.push(`--job-key=${github.context.job}`)
     try {

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -149,9 +149,10 @@ export async function generateSummary(): Promise<void> {
     // Build summary command args
     const summaryArgs = ['summary', '--audit-log', AUDIT_LOG, '--steps', stepsJson]
 
-    // Add API push flags if api-url is configured
+    // Add API push flags if api-url is configured and offline mode is not enabled
+    const offline = core.getInput('offline') === 'true'
     const apiUrl = core.getInput('api-url')
-    if (apiUrl) {
+    if (apiUrl && !offline) {
       summaryArgs.push('--api-url', apiUrl)
       summaryArgs.push('--job-key', github.context.job)
       summaryArgs.push('--job-name', currentJobName || github.context.job)
@@ -178,6 +179,11 @@ export async function generateSummary(): Promise<void> {
         core.warning(
           `Failed to get OIDC token for API push. Ensure the workflow has "permissions: id-token: write". Error: ${error}`
         )
+        // Remove API-related args so the binary doesn't attempt an unauthenticated push
+        for (const flag of ['--api-url', '--job-key', '--job-name', '--mode', '--default-action', '--job-status']) {
+          const idx = summaryArgs.findIndex(a => a === flag)
+          if (idx !== -1) summaryArgs.splice(idx, 2) // remove flag and its value
+        }
       }
     }
 


### PR DESCRIPTION
Closes #26 

- defaults the cargowall api-url to `app.codecargo.com`
    - if `id-token: write` is not provided log warning and fallback to offline mode
- Adds an `offline` option to 