### PR TITLE
#28 Add security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in the CargoWall GitHub Action, please report it through [GitHub Security Advisories](https://github.com/code-cargo/cargowall-action/security/advisories/new).
+
+Please include:
+
+* A description of the vulnerability
+* Steps to reproduce
+* Any relevant logs or screenshots
+
+We will acknowledge your report within 48 hours and aim to provide a fix or mitigation plan within 7 business days.
+
+## Scope
+
+This policy covers the CargoWall GitHub Action — the installation, configuration, and orchestration layer that runs [CargoWall](https://github.com/code-cargo/cargowall) in GitHub Actions workflows.
+
+For vulnerabilities in CargoWall itself (the eBPF programs, userspace daemon, DNS proxy, or configuration handling), please report them to the [main CargoWall repository](https://github.com/code-cargo/cargowall/security/advisories/new).
+
+## Supported Versions
+
+Security fixes are applied to the latest release only.


### PR DESCRIPTION
Adds security.md to the repo - references code-cargo/cargowall as appropriate 
closes #28 
