### PR TITLE
#38 add job_run_id

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,12 +112,11 @@ jobs:
       - name: Setup CargoWall with strict hosts
         uses: ./
         with:
+          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             app.codecargo.com
             github.com
             api.github.com
-
-
 
       - name: Test allowed DNS query
         run: |
@@ -153,6 +152,7 @@ jobs:
       - name: Setup CargoWall with CIDR rules
         uses: ./
         with:
+          api-url: https://app.dev.codecargo.dev
           allowed-cidrs: |
             "140.82.112.0/20"  # GitHub's IP range
           allowed-hosts: |
@@ -178,6 +178,7 @@ jobs:
         id: cargowall
         uses: ./
         with:
+          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             app.codecargo.com
             github.com
@@ -200,6 +201,7 @@ jobs:
       - name: Setup CargoWall
         uses: ./
         with:
+          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             github.com
             app.codecargo.com
@@ -238,6 +240,7 @@ jobs:
       - name: Setup CargoWall with sudo lockdown
         uses: ./
         with:
+          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             app.codecargo.com
             github.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,11 +112,12 @@ jobs:
       - name: Setup CargoWall with strict hosts
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             app.codecargo.com
             github.com
             api.github.com
+
+
 
       - name: Test allowed DNS query
         run: |
@@ -152,7 +153,6 @@ jobs:
       - name: Setup CargoWall with CIDR rules
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-cidrs: |
             "140.82.112.0/20"  # GitHub's IP range
           allowed-hosts: |
@@ -178,7 +178,6 @@ jobs:
         id: cargowall
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             app.codecargo.com
             github.com
@@ -201,7 +200,6 @@ jobs:
       - name: Setup CargoWall
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             github.com
             app.codecargo.com
@@ -240,7 +238,6 @@ jobs:
       - name: Setup CargoWall with sudo lockdown
         uses: ./
         with:
-          api-url: https://app.dev.codecargo.dev
           allowed-hosts: |
             app.codecargo.com
             github.com

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ inputs:
     description: 'Skip all CodeCargo API communication (audit upload and policy fetch)'
     default: 'false'
   job-id:
-    description: 'The check run ID of the current job (auto-detected)'
+    description: 'The check run ID of the current job (populated from the workflow context by default; override if needed)'
     default: ${{ job.check_run_id }}
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
   offline:
     description: 'Skip all CodeCargo API communication (audit upload and policy fetch)'
     default: 'false'
+  job-id:
+    description: 'The check run ID of the current job (auto-detected)'
+    default: ${{ job.check_run_id }}
 
 outputs:
   supported:

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21513,7 +21513,7 @@ var os6 = __toESM(require("os"));
 var path4 = __toESM(require("path"));
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.0.1-rc.0";
+var CARGOWALL_VERSION = "v1.0.1";
 async function setup() {
   const failOnUnsupported = getInput("fail-on-unsupported") === "true";
   const binaryPath = getInput("binary-path");

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21513,7 +21513,7 @@ var os6 = __toESM(require("os"));
 var path4 = __toESM(require("path"));
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.0.0";
+var CARGOWALL_VERSION = "v1.0.1-rc.0";
 async function setup() {
   const failOnUnsupported = getInput("fail-on-unsupported") === "true";
   const binaryPath = getInput("binary-path");

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -25886,6 +25886,8 @@ async function start() {
   if (githubServiceHosts) info(`  GitHub service hosts: ${githubServiceHosts}`);
   if (azureInfraHosts) info(`  Azure infra hosts: ${azureInfraHosts}`);
   if (configFile) info(`  Config file: ${configFile}`);
+  const jobId = getInput("job-id");
+  if (jobId) info(`  Job ID (check_run_id): ${jobId}`);
   info(`  Sudo lockdown: ${sudoLockdown}`);
   info(`  DNS upstream: ${dnsUpstream}`);
   try {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -25887,7 +25887,7 @@ async function start() {
   if (azureInfraHosts) info(`  Azure infra hosts: ${azureInfraHosts}`);
   if (configFile) info(`  Config file: ${configFile}`);
   const jobId = getInput("job-id");
-  if (jobId) info(`  Job ID (check_run_id): ${jobId}`);
+  if (jobId) info(`  Job run ID: ${jobId}`);
   info(`  Sudo lockdown: ${sudoLockdown}`);
   info(`  DNS upstream: ${dnsUpstream}`);
   try {

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -25407,6 +25407,20 @@ async function generateSummary() {
       summaryArgs.push("--api-url", apiUrl);
       summaryArgs.push("--job-key", context2.job);
       summaryArgs.push("--job-name", currentJobName);
+      const jobId = getInput("job-id");
+      if (jobId) {
+        let helpOutput = "";
+        await exec("cargowall", ["summary", "--help"], {
+          ignoreReturnCode: true,
+          silent: true,
+          listeners: { stdout: (data) => {
+            helpOutput += data.toString();
+          } }
+        });
+        if (helpOutput.includes("job-run-id")) {
+          summaryArgs.push("--job-run-id", jobId);
+        }
+      }
       let effectiveMode = getInput("mode") || "enforce";
       try {
         const modeFromFile = (await import_fs6.promises.readFile("/tmp/cargowall-mode", "utf8")).trim();
@@ -25425,7 +25439,7 @@ async function generateSummary() {
         warning(
           `Failed to get OIDC token for API push. Ensure the workflow has "permissions: id-token: write". Error: ${error}`
         );
-        for (const flag of ["--api-url", "--job-key", "--job-name", "--mode", "--default-action", "--job-status"]) {
+        for (const flag of ["--api-url", "--job-key", "--job-name", "--job-run-id", "--mode", "--default-action", "--job-status"]) {
           const idx = summaryArgs.findIndex((a) => a === flag);
           if (idx !== -1) summaryArgs.splice(idx, 2);
         }

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -25409,17 +25409,7 @@ async function generateSummary() {
       summaryArgs.push("--job-name", currentJobName);
       const jobId = getInput("job-id");
       if (jobId) {
-        let helpOutput = "";
-        await exec("cargowall", ["summary", "--help"], {
-          ignoreReturnCode: true,
-          silent: true,
-          listeners: { stdout: (data) => {
-            helpOutput += data.toString();
-          } }
-        });
-        if (helpOutput.includes("job-run-id")) {
-          summaryArgs.push("--job-run-id", jobId);
-        }
+        summaryArgs.push("--job-run-id", jobId);
       }
       let effectiveMode = getInput("mode") || "enforce";
       try {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.0.0'
+const CARGOWALL_VERSION = 'v1.0.1-rc.0'
 
 export async function setup(): Promise<boolean> {
   const failOnUnsupported = core.getInput('fail-on-unsupported') === 'true'

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.0.1-rc.0'
+const CARGOWALL_VERSION = 'v1.0.1'
 
 export async function setup(): Promise<boolean> {
   const failOnUnsupported = core.getInput('fail-on-unsupported') === 'true'

--- a/src/start.ts
+++ b/src/start.ts
@@ -170,6 +170,8 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   if (githubServiceHosts) core.info(`  GitHub service hosts: ${githubServiceHosts}`)
   if (azureInfraHosts) core.info(`  Azure infra hosts: ${azureInfraHosts}`)
   if (configFile) core.info(`  Config file: ${configFile}`)
+  const jobId = core.getInput('job-id')
+  if (jobId) core.info(`  Job ID (check_run_id): ${jobId}`)
   core.info(`  Sudo lockdown: ${sudoLockdown}`)
   core.info(`  DNS upstream: ${dnsUpstream}`)
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -171,7 +171,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   if (azureInfraHosts) core.info(`  Azure infra hosts: ${azureInfraHosts}`)
   if (configFile) core.info(`  Config file: ${configFile}`)
   const jobId = core.getInput('job-id')
-  if (jobId) core.info(`  Job ID (check_run_id): ${jobId}`)
+  if (jobId) core.info(`  Job run ID: ${jobId}`)
   core.info(`  Sudo lockdown: ${sudoLockdown}`)
   core.info(`  DNS upstream: ${dnsUpstream}`)
 

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -128,6 +128,17 @@ export async function generateSummary(): Promise<void> {
       summaryArgs.push('--api-url', apiUrl)
       summaryArgs.push('--job-key', github.context.job)
       summaryArgs.push('--job-name', currentJobName)
+      const jobId = core.getInput('job-id')
+      if (jobId) {
+        let helpOutput = ''
+        await exec.exec('cargowall', ['summary', '--help'], {
+          ignoreReturnCode: true, silent: true,
+          listeners: { stdout: (data: Buffer) => { helpOutput += data.toString() } }
+        })
+        if (helpOutput.includes('job-run-id')) {
+          summaryArgs.push('--job-run-id', jobId)
+        }
+      }
 
       // Prefer the effective mode written by the Go binary (which may have
       // been overridden by the SaaS policy) over the static Action input.
@@ -156,7 +167,7 @@ export async function generateSummary(): Promise<void> {
           `Failed to get OIDC token for API push. Ensure the workflow has "permissions: id-token: write". Error: ${error}`
         )
         // Remove API-related args so the binary doesn't attempt an unauthenticated push
-        for (const flag of ['--api-url', '--job-key', '--job-name', '--mode', '--default-action', '--job-status']) {
+        for (const flag of ['--api-url', '--job-key', '--job-name', '--job-run-id', '--mode', '--default-action', '--job-status']) {
           const idx = summaryArgs.findIndex(a => a === flag)
           if (idx !== -1) summaryArgs.splice(idx, 2) // remove flag and its value
         }

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -130,14 +130,7 @@ export async function generateSummary(): Promise<void> {
       summaryArgs.push('--job-name', currentJobName)
       const jobId = core.getInput('job-id')
       if (jobId) {
-        let helpOutput = ''
-        await exec.exec('cargowall', ['summary', '--help'], {
-          ignoreReturnCode: true, silent: true,
-          listeners: { stdout: (data: Buffer) => { helpOutput += data.toString() } }
-        })
-        if (helpOutput.includes('job-run-id')) {
-          summaryArgs.push('--job-run-id', jobId)
-        }
+        summaryArgs.push('--job-run-id', jobId)
       }
 
       // Prefer the effective mode written by the Go binary (which may have


### PR DESCRIPTION
closes #38 

TODO:
- [x] publish `cargowall` `v1.0.1`
- [x] update `setup.ts` `CARGOWALL_VERSION` to refer to `v1.0.1`
- [x] remove the check logic around `--job-run-id` (`v1.0.1` will have `--job-run-id`)