### PR TITLE
Update cargowall to v1.2.0-rc.0

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   update-tag:
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21560,7 +21560,7 @@ var import_promises = require("stream/promises");
 var import_promises2 = require("timers/promises");
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.1.0";
+var CARGOWALL_VERSION = "v1.2.0-rc.0";
 var http2 = new HttpClient("cargowall-action");
 async function downloadAsset(url, dest) {
   const attempt = async () => {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'timers/promises'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.1.0'
+const CARGOWALL_VERSION = 'v1.2.0-rc.0'
 
 const http = new HttpClient('cargowall-action')
 


### PR DESCRIPTION
- Updates cargowall to `v1.2.0-rc.0`
- Will create cargowall-action `v1.2.0-rc.0` and verify 

Create follow up full release for `v1.2.0` of both