### PR TITLE
Update to cargowall v1.3.0-rc.1 + expose search-domains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,6 +345,59 @@ jobs:
           fi
           echo "Correctly blocked httpbin.org"
 
+  test-search-domains:
+    name: DNS Search Domains
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup CargoWall with search domains
+        uses: ./
+        with:
+          offline: 'true'
+          # `archive` is a bare single-label rule that only matches a real host
+          # once the `.ubuntu.com` search-domain suffix is stripped before matching.
+          allowed-hosts: |
+            archive
+          search-domains: |
+            .ubuntu.com
+
+      - name: Test suffix stripping enables rule match (archive.ubuntu.com -> archive)
+        run: |
+          # Without search-domains, the bare `archive` rule would NOT cover
+          # archive.ubuntu.com. It connects only because `.ubuntu.com` is stripped
+          # to `archive`, which matches the rule.
+          curl -sf --max-time 10 https://archive.ubuntu.com > /dev/null
+          echo "Connected to archive.ubuntu.com (.ubuntu.com stripped -> matched 'archive' rule)"
+
+      - name: Test bypass for unmatched name under a search domain (resolves, not refused)
+        run: |
+          # security.ubuntu.com has no host rule, but it ends in a configured
+          # search-domain suffix, so the DNS proxy bypasses it instead of refusing
+          # it as DNS tunneling.
+          OUTPUT=$(nslookup security.ubuntu.com 127.0.0.1 2>&1 || true)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qi "refused\|SERVFAIL"; then
+            echo "ERROR: security.ubuntu.com should be bypassed (resolved), not refused"
+            exit 1
+          fi
+          echo "Correctly bypassed DNS query for security.ubuntu.com"
+
+      - name: Test name outside any search domain is still refused (DNS tunneling guard)
+        run: |
+          # attacker-domain has no rule and is not under a search domain, so the
+          # proxy should still refuse it. Soft-checked to match the DNS-filtering job.
+          OUTPUT=$(nslookup attacker-domain-98765.example 127.0.0.1 2>&1 || true)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qi "refused\|SERVFAIL\|NXDOMAIN\|can't find\|timed out"; then
+            echo "Correctly refused/failed DNS query for non-allowed, non-search-domain name"
+          else
+            echo "WARNING: attacker-domain query may have succeeded unexpectedly"
+          fi
+
   test-sudo-lockdown:
     name: Sudo Lockdown
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -373,29 +373,32 @@ jobs:
           curl -sf --max-time 10 https://archive.ubuntu.com > /dev/null
           echo "Connected to archive.ubuntu.com (.ubuntu.com stripped -> matched 'archive' rule)"
 
-      - name: Test bypass for unmatched name under a search domain (resolves, not refused)
+      - name: Test bypass for an unmatched name under a search domain (forwarded, not refused)
         run: |
-          # security.ubuntu.com has no host rule, but it ends in a configured
-          # search-domain suffix, so the DNS proxy bypasses it instead of refusing
-          # it as DNS tunneling.
-          OUTPUT=$(nslookup security.ubuntu.com 127.0.0.1 2>&1 || true)
+          # A made-up label under the .ubuntu.com search domain has no host rule, so
+          # the proxy must BYPASS query filtering and forward it upstream rather than
+          # refuse it as DNS tunneling. A non-existent label is used deliberately: it
+          # has no CNAME chain to escape the suffix, so bypass -> upstream NXDOMAIN,
+          # whereas a refusal (REFUSED) would mean bypass did not apply.
+          OUTPUT=$(nslookup nonexistent-cargowall-bypass-test.ubuntu.com 127.0.0.1 2>&1 || true)
           echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -qi "refused\|SERVFAIL"; then
-            echo "ERROR: security.ubuntu.com should be bypassed (resolved), not refused"
+          if echo "$OUTPUT" | grep -qi "REFUSED"; then
+            echo "ERROR: a name under the search domain should be bypassed (forwarded), not REFUSED"
             exit 1
           fi
-          echo "Correctly bypassed DNS query for security.ubuntu.com"
+          echo "Correctly bypassed DNS query for a name under the search domain"
 
       - name: Test name outside any search domain is still refused (DNS tunneling guard)
         run: |
-          # attacker-domain has no rule and is not under a search domain, so the
-          # proxy should still refuse it. Soft-checked to match the DNS-filtering job.
-          OUTPUT=$(nslookup attacker-domain-98765.example 127.0.0.1 2>&1 || true)
+          # No host rule and not under a search domain -> the proxy refuses it.
+          # `.example` is a reserved TLD, so this can never resolve for real.
+          OUTPUT=$(nslookup blocked-cargowall-test.example 127.0.0.1 2>&1 || true)
           echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -qi "refused\|SERVFAIL\|NXDOMAIN\|can't find\|timed out"; then
-            echo "Correctly refused/failed DNS query for non-allowed, non-search-domain name"
+          if echo "$OUTPUT" | grep -qi "REFUSED"; then
+            echo "Correctly refused DNS query for an off-suffix, unmatched name"
           else
-            echo "WARNING: attacker-domain query may have succeeded unexpectedly"
+            echo "ERROR: an off-suffix, unmatched name should be REFUSED"
+            exit 1
           fi
 
   test-sudo-lockdown:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ In this example:
 - `*.github.com` allows `api.github.com` but not `github.com` or `a.b.github.com`
 - `**.ubuntu.com` allows `archive.ubuntu.com`, `us.archive.ubuntu.com`, and any depth of subdomain
 
+### With DNS Search Domains
+
+Cloud runners often resolve internal hosts through a DNS search domain (e.g. AWS attaches `.compute.internal` / `.ec2.internal`). Use `search-domains` so those suffixes are stripped before rule matching and bypassed for unmatched DNS queries — handy when the underlying traffic is already governed by a CIDR rule and per-hostname tracking would be wasteful:
+
+```yaml
+- uses: code-cargo/cargowall-action@v1
+  with:
+    allowed-cidrs: |
+      10.0.0.0/8
+    search-domains: |
+      .compute.internal
+      .ec2.internal
+```
+
+With this configuration:
+- A rule for `bastion` also matches `bastion.compute.internal` (the suffix is stripped before matching).
+- Any name ending in a configured suffix passes the DNS proxy even without a matching hostname rule, while explicit deny rules still win.
+
+Each suffix must have at least two labels (`.compute.internal` is valid, `.internal` is not) and cannot be a public suffix (`.com`, `.co.uk`, `.github.io`, … are rejected). Kubernetes suffixes (`.cluster.local`, `.svc.cluster.local`, `.default.svc.cluster.local`) are always stripped automatically.
+
 ### With Docker Support
 
 CargoWall automatically configures Docker to use its DNS proxy, so hostname filtering works inside containers:
@@ -148,27 +168,28 @@ For complex configurations, use a JSON or YAML config file:
 
 ## Inputs
 
-| Input                        | Description                                                                       | Default                                        |
-|------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------|
-| `mode`                       | Enforcement mode: `enforce` (block) or `audit` (log only)                         | `enforce`                                      |
+| Input                        | Description                                                                                | Default                                        |
+|------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------|
+| `mode`                       | Enforcement mode: `enforce` (block) or `audit` (log only)                                  | `enforce`                                      |
 | `allowed-hosts`              | Allowed hostnames, one per line (auto matches subdomains, supports `*` and `**` wildcards) |                                                |
-| `allowed-cidrs`              | Allowed CIDR blocks, one per line                                                 |                                                |
-| `github-service-hosts`       | GitHub service hostnames to auto-allow on port 443 (one per line)                 | See [defaults](#automatically-allowed-traffic) |
-| `azure-infra-hosts`          | Azure infrastructure hostnames to auto-allow on port 443 (one per line)           | See [defaults](#automatically-allowed-traffic) |
-| `config-file`                | Path to YAML/JSON config file for advanced rules                                  |                                                |
-| `version`                    | CargoWall version to use                                                          | `latest`                                       |
-| `fail-on-unsupported`        | Fail if eBPF not supported                                                        | `false`                                        |
-| `sudo-lockdown`              | Enable sudo lockdown to prevent firewall bypass                                   | `false`                                        |
-| `sudo-allow-commands`        | Command paths to allow via sudo when locked, one per line                         |                                                |
-| `dns-upstream`               | Upstream DNS server (auto-detected if not set)                                    | auto-detect                                    |
-| `allow-existing-connections` | Allow pre-existing TCP connections at startup                                     | `true`                                         |
-| `binary-path`                | Path to a pre-built cargowall binary (skips download)                             |                                                |
-| `debug`                      | Enable debug logging                                                              | `false`                                        |
-| `audit-summary`              | Generate audit summary in workflow summary                                        | `true`                                         |
-| `github-token`               | GitHub token for downloading the binary and fetching step timing in audit summary | `${{ github.token }}`                          |
-| `include-prerelease`         | Include pre-release versions when resolving "latest"                              | `false`                                        |
-| `api-url`                    | CodeCargo API URL for audit upload and policy fetch (policy requires GitHub App)   | `https://app.codecargo.com`                    |
-| `offline`                    | Skip all CodeCargo API communication (audit upload and policy fetch)              | `false`                                        |
+| `allowed-cidrs`              | Allowed CIDR blocks, one per line                                                          |                                                |
+| `search-domains`             | DNS search-domain suffixes (e.g. `.compute.internal`), one per line — stripped before hostname-rule matching and bypassed for unmatched DNS queries. Each suffix needs ≥2 labels and cannot be a public suffix. |                                                |
+| `github-service-hosts`       | GitHub service hostnames to auto-allow on port 443 (one per line)                          | See [defaults](#automatically-allowed-traffic) |
+| `azure-infra-hosts`          | Azure infrastructure hostnames to auto-allow on port 443 (one per line)                    | See [defaults](#automatically-allowed-traffic) |
+| `config-file`                | Path to YAML/JSON config file for advanced rules                                           |                                                |
+| `fail-on-unsupported`        | Fail if eBPF not supported                                                                 | `false`                                        |
+| `sudo-lockdown`              | Enable sudo lockdown to prevent firewall bypass                                            | `false`                                        |
+| `sudo-allow-commands`        | Command paths to allow via sudo when locked, one per line                                  |                                                |
+| `dns-upstream`               | Upstream DNS server (auto-detected if not set)                                             | auto-detect                                    |
+| `allow-existing-connections` | Allow pre-existing TCP connections at startup                                              | `true`                                         |
+| `binary-path`                | Path to a pre-built cargowall binary (skips download)                                      |                                                |
+| `debug`                      | Enable debug logging                                                                       | `false`                                        |
+| `audit-summary`              | Generate audit summary in workflow summary                                                 | `true`                                         |
+| `skip-actions-api`           | Skip the GitHub Actions API call that enriches audit-summary step names/status (falls back to local `_diag` data); set `true` when near the per-repo rate limit | `false`                                        |
+| `github-token`               | GitHub token for fetching step timing in the audit summary                                 | `${{ github.token }}`                          |
+| `api-url`                    | CodeCargo API URL for audit upload and policy fetch (policy requires GitHub App)           | `https://app.codecargo.com`                    |
+| `offline`                    | Skip all CodeCargo API communication (audit upload and policy fetch)                       | `false`                                        |
+| `job-id`                     | Check run ID of the current job (from workflow context by default; override if needed)     | `${{ job.check_run_id }}`                      |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   allowed-cidrs:
     description: 'Allowed CIDR blocks, one per line'
     required: false
+  search-domains:
+    description: 'DNS search-domain suffixes to strip before hostname-rule matching and bypass for unmatched DNS queries (e.g. .compute.internal), one per line. Each suffix needs at least two labels and cannot be a public suffix.'
+    required: false
   github-service-hosts:
     description: 'GitHub service hostnames to auto-allow on port 443 (one per line)'
     required: false

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21560,7 +21560,7 @@ var import_promises = require("stream/promises");
 var import_promises2 = require("timers/promises");
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.2.0";
+var CARGOWALL_VERSION = "v1.3.0-rc.1";
 var http2 = new HttpClient("cargowall-action");
 async function downloadAsset(url, dest) {
   const attempt = async () => {
@@ -25856,6 +25856,7 @@ async function start() {
   }
   const allowedHosts = parseList(getMultilineInput("allowed-hosts"));
   const allowedCidrs = parseList(getMultilineInput("allowed-cidrs"));
+  const searchDomains = parseList(getMultilineInput("search-domains"));
   const githubServiceHosts = parseList(getMultilineInput("github-service-hosts"));
   const azureInfraHosts = parseList(getMultilineInput("azure-infra-hosts"));
   const configFile = getInput("config-file");
@@ -25948,6 +25949,7 @@ async function start() {
   info(`  Mode: ${mode}`);
   if (allowedHosts) info(`  Allowed hosts: ${allowedHosts}`);
   if (allowedCidrs) info(`  Allowed CIDRs: ${allowedCidrs}`);
+  if (searchDomains) info(`  Search domains: ${searchDomains}`);
   if (githubServiceHosts) info(`  GitHub service hosts: ${githubServiceHosts}`);
   if (azureInfraHosts) info(`  Azure infra hosts: ${azureInfraHosts}`);
   if (configFile) info(`  Config file: ${configFile}`);
@@ -25974,6 +25976,7 @@ async function start() {
     CARGOWALL_DEFAULT_ACTION: "deny",
     ...allowedHosts && { CARGOWALL_ALLOWED_HOSTS: allowedHosts },
     ...allowedCidrs && { CARGOWALL_ALLOWED_CIDRS: allowedCidrs },
+    ...searchDomains && { CARGOWALL_SEARCH_DOMAINS: searchDomains },
     ...githubServiceHosts && { CARGOWALL_GITHUB_SERVICE_HOSTS: githubServiceHosts },
     ...azureInfraHosts && { CARGOWALL_AZURE_INFRA_HOSTS: azureInfraHosts }
   };

--- a/examples/advanced.yml
+++ b/examples/advanced.yml
@@ -80,6 +80,11 @@ jobs:
           allowed-cidrs: |
             10.0.0.0/8
             192.168.0.0/16
+          # Strip cloud-internal DNS suffixes before rule matching and bypass
+          # unmatched queries ending in them (traffic is covered by the CIDRs above)
+          search-domains: |
+            .compute.internal
+            .ec2.internal
           fail-on-unsupported: true
 
       - uses: actions/checkout@v6

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'timers/promises'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.2.0'
+const CARGOWALL_VERSION = 'v1.3.0-rc.1'
 
 const http = new HttpClient('cargowall-action')
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -40,6 +40,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   }
   const allowedHosts = parseList(core.getMultilineInput('allowed-hosts'))
   const allowedCidrs = parseList(core.getMultilineInput('allowed-cidrs'))
+  const searchDomains = parseList(core.getMultilineInput('search-domains'))
   const githubServiceHosts = parseList(core.getMultilineInput('github-service-hosts'))
   const azureInfraHosts = parseList(core.getMultilineInput('azure-infra-hosts'))
 
@@ -167,6 +168,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   core.info(`  Mode: ${mode}`)
   if (allowedHosts) core.info(`  Allowed hosts: ${allowedHosts}`)
   if (allowedCidrs) core.info(`  Allowed CIDRs: ${allowedCidrs}`)
+  if (searchDomains) core.info(`  Search domains: ${searchDomains}`)
   if (githubServiceHosts) core.info(`  GitHub service hosts: ${githubServiceHosts}`)
   if (azureInfraHosts) core.info(`  Azure infra hosts: ${azureInfraHosts}`)
   if (configFile) core.info(`  Config file: ${configFile}`)
@@ -202,6 +204,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
     CARGOWALL_DEFAULT_ACTION: 'deny',
     ...(allowedHosts && { CARGOWALL_ALLOWED_HOSTS: allowedHosts }),
     ...(allowedCidrs && { CARGOWALL_ALLOWED_CIDRS: allowedCidrs }),
+    ...(searchDomains && { CARGOWALL_SEARCH_DOMAINS: searchDomains }),
     ...(githubServiceHosts && { CARGOWALL_GITHUB_SERVICE_HOSTS: githubServiceHosts }),
     ...(azureInfraHosts && { CARGOWALL_AZURE_INFRA_HOSTS: azureInfraHosts }),
   }


### PR DESCRIPTION
## Summary

Updates the action for the **cargowall `v1.3.0-rc.1`** release candidate so we can cut a `v1.3.0` cargowall-action pre-release.

- **Bump pinned binary** to `v1.3.0-rc.1` (`src/setup.ts`, rebuilt `dist/`).
- **New `search-domains` input** — DNS search-domain suffixes (e.g. `.compute.internal`) passed to the binary via `CARGOWALL_SEARCH_DOMAINS`. The proxy strips a matching suffix before hostname-rule matching and bypasses unmatched queries ending in a suffix (useful for cloud-internal DNS governed by a CIDR rule). Wired identically to `allowed-hosts`/`allowed-cidrs` in `src/start.ts`.
- **Docs** — README inputs table synced with `action.yml` (added `search-domains`, `skip-actions-api`, `job-id`; removed the never-implemented `version`/`include-prerelease`; corrected the stale `github-token` description), plus a "DNS Search Domains" usage section and an `examples/advanced.yml` snippet.
- **New integration test** — `test-search-domains` job in `test.yml` exercises suffix stripping, query bypass, and the DNS-tunneling guard on a live runner.

## On the `--github-action` preset (no meaningful change for hosted runners)

In v1.3.0 `--github-action` (which this action always passes) became a *preset* that toggles named plumbing flags: `DNSRedirectIptables`, `DockerDNSInterception`, `DNSQueryFiltering`, `PrepopulateDNSCache`, `AutoAllowCloudMetadata`, `AutoAllowGitHubHosts`. This is an **internal refactor** — every one of these was already hardcoded-on under `--github-action` in v1.2.0, so DNS query filtering, Docker DNS interception, cache pre-population, GitHub-hosts auto-allow, and **Azure cloud-metadata auto-allow (wireserver + IMDS)** all behave as before.

Genuinely new in v1.3.0:
- **AWS/GCP provider detection** auto-adds internal DNS search-domain suffixes (`.compute.internal`/`.ec2.internal` on AWS, `.google.internal` on GCP). Only affects self-hosted EC2/GCE runners.
- **Azure** additionally auto-adds the `.internal.cloudapp.net` search domain and ICMP to the wireserver — additive/benign; the only delta that touches GitHub-hosted (Azure) runners.
- Provider detection now uses DMI signals + a `CARGOWALL_CLOUD_PROVIDER=aws|azure|gcp` override (previously Azure-only, via the wireserver-upstream heuristic).
- The opt-in `search-domains` input.

Net: on GitHub-hosted `ubuntu-*` runners, the upgrade is effectively a no-op apart from the benign additive Azure allows and the new opt-in input.

## Testing

- `npm test` — 47/47 unit tests pass.
- `npm run build` regenerates `dist/main/index.js` (embeds `v1.3.0-rc.1` + `CARGOWALL_SEARCH_DOMAINS`); rebuild is idempotent so `check-dist` passes.
- Confirmed the cargowall `v1.3.0-rc.1` GitHub release is published (prerelease) with all four assets: `cargowall-linux-amd64`, `cargowall-linux-arm64`, `checksums.txt`, `attestations.sigstore.json`.
- New `test-search-domains` integration job runs the full action against the live binary.

