### PR TITLE
Fix false "CargoWall failed to start" under v1.3.0 (--pidfile/readiness)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup CargoWall
+        id: cargowall
         uses: ./
         with:
           offline: 'true'
@@ -27,6 +28,18 @@ jobs:
             github.com
             githubusercontent.com
             api.github.com
+
+      - name: Verify pid output is the real cargowall process (not the sudo wrapper)
+        run: |
+          PID='${{ steps.cargowall.outputs.pid }}'
+          test -n "$PID"
+          # /proc/<pid>/comm is world-readable, so ps works without sudo.
+          COMM=$(ps -o comm= -p "$PID" | tr -d '[:space:]')
+          echo "pid=$PID comm=$COMM"
+          if [ "$COMM" != "cargowall" ]; then
+            echo "ERROR: pid output should be the cargowall process, got '$COMM'"
+            exit 1
+          fi
 
       - name: Test allowed connection (github.com)
         run: |
@@ -45,7 +58,7 @@ jobs:
             exit 1
           fi
           echo "Correctly blocked example.com"
-        
+
       - name: Test blocked connection (httpbin.org)
         run: |
           if curl -sf --max-time 5 https://httpbin.org > /dev/null 2>&1; then
@@ -412,6 +425,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup CargoWall with sudo lockdown
+        id: cargowall
         uses: ./
         with:
           allowed-hosts: |
@@ -421,6 +435,22 @@ jobs:
             security.ubuntu.com
           sudo-lockdown: true
           sudo-allow-commands: /usr/bin/apt-get
+          # Make a false "exited unexpectedly" liveness verdict a hard failure.
+          # Under lockdown the action can't probe liveness via sudo, so this
+          # guards the tri-state 'unknown' path (must wait for the sentinel, not
+          # crash) as well as the no-sudo pidfile read below.
+          fail-on-unsupported: true
+
+      - name: Verify real PID is tracked under sudo-lockdown
+        run: |
+          # The pidfile is 0644, so an unprivileged step reads it even under
+          # lockdown; the action must report that same (real) PID, not the wrapper.
+          OUT='${{ steps.cargowall.outputs.pid }}'
+          FILE=$(cat /tmp/cargowall.pid)
+          echo "output=$OUT file=$FILE"
+          test -n "$OUT"
+          test "$OUT" = "$FILE"
+          ps -o comm= -p "$OUT" | tr -d '[:space:]' | grep -qx cargowall
 
       - name: Test apt-get works
         run: |
@@ -433,3 +463,103 @@ jobs:
           else
             echo "Correctly blocked iptables"
           fi
+
+  test-stale-startup-files:
+    name: Stale Startup Files (reused runner)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Plant stale ready/pid files (simulate a prior run on a reused runner)
+        run: |
+          # Root-owned, like the files cargowall leaves behind. Without the
+          # action clearing them, the stale ready sentinel would short-circuit the
+          # wait and the stale dead PID would trip a false "exited" verdict.
+          echo 999999 | sudo tee /tmp/cargowall.pid > /dev/null
+          sudo touch /tmp/cargowall-ready
+          ls -l /tmp/cargowall.pid /tmp/cargowall-ready
+
+      - name: Setup CargoWall
+        id: cargowall
+        uses: ./
+        with:
+          offline: 'true'
+          fail-on-unsupported: true
+          allowed-hosts: |
+            github.com
+            api.github.com
+
+      - name: Verify clean start despite stale files
+        run: |
+          test '${{ steps.cargowall.outputs.supported }}' = 'true'
+          PID='${{ steps.cargowall.outputs.pid }}'
+          echo "pid=$PID"
+          test -n "$PID"
+          # Must be the real cargowall PID, not the planted stale 999999.
+          test "$PID" != "999999"
+          ps -o comm= -p "$PID" | tr -d '[:space:]' | grep -qx cargowall
+
+      - name: Test allowed connection (github.com)
+        run: |
+          curl -sf --max-time 10 https://github.com > /dev/null
+          echo "Successfully connected to github.com"
+
+      - name: Test blocked connection (example.com)
+        run: |
+          if curl -sf --max-time 5 https://example.com > /dev/null 2>&1; then
+            echo "ERROR: example.com should be blocked"
+            exit 1
+          fi
+          echo "Correctly blocked example.com"
+
+  test-fail-on-unsupported-cleanup:
+    name: Fail-on-unsupported restores DNS
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create a fake cargowall that records its PID then exits
+        run: |
+          # Stand-in binary: writes the pidfile cargowall would, then exits
+          # without ever writing the ready sentinel. The action sees a real but
+          # dead PID -> 'dead' liveness -> startup failure. With
+          # fail-on-unsupported the action must throw AND restore resolv.conf
+          # (which start() repointed at 127.0.0.1 before launching).
+          printf '%s\n' \
+            '#!/usr/bin/env bash' \
+            'for a in "$@"; do case "$a" in --pidfile=*) echo "$$" > "${a#--pidfile=}";; esac; done' \
+            'exit 0' > /tmp/fake-cargowall
+          chmod +x /tmp/fake-cargowall
+
+      - name: Capture DNS before
+        run: cat /etc/resolv.conf
+
+      - name: Setup CargoWall (expected to fail)
+        id: cw
+        continue-on-error: true
+        uses: ./
+        with:
+          offline: 'true'
+          binary-path: /tmp/fake-cargowall
+          fail-on-unsupported: true
+          allowed-hosts: github.com
+
+      - name: Assert startup failed and DNS was restored
+        run: |
+          if [ '${{ steps.cw.outcome }}' != 'failure' ]; then
+            echo "ERROR: expected the action to fail, got '${{ steps.cw.outcome }}'"
+            exit 1
+          fi
+          echo "resolv.conf after:"; cat /etc/resolv.conf
+          if grep -qF 'nameserver 127.0.0.1' /etc/resolv.conf; then
+            echo "ERROR: /etc/resolv.conf still points at cargowall's proxy (DNS not restored)"
+            exit 1
+          fi
+          # DNS must actually resolve again.
+          getent hosts github.com

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -25978,6 +25978,7 @@ async function start() {
     await restoreDns();
   }
   info("Starting cargowall...");
+  await clearStartupFiles();
   const env = {
     ...process.env,
     CARGOWALL_DEFAULT_ACTION: "deny",
@@ -26033,6 +26034,7 @@ async function start() {
     );
   }
   info("CargoWall is ready");
+  await makePidFileReadable();
   cargowallPid = cargowallPid ?? await readPidFile();
   const reportedPid = cargowallPid ?? spawnedPid;
   setOutput("supported", "true");
@@ -26069,6 +26071,18 @@ async function readPidFile() {
   if (rc !== 0) return null;
   const pid = parseInt(out.trim(), 10);
   return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+async function clearStartupFiles() {
+  await exec("sudo", ["rm", "-f", READY_FILE, PID_FILE], {
+    ignoreReturnCode: true,
+    silent: true
+  });
+}
+async function makePidFileReadable() {
+  await exec("sudo", ["chmod", "644", PID_FILE], {
+    ignoreReturnCode: true,
+    silent: true
+  });
 }
 async function stopCargowall(pids) {
   for (const pid of pids) {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -26057,7 +26057,7 @@ async function processLiveness(pid) {
   return "dead";
 }
 async function sudoKillZero(pid) {
-  const rc = await exec("sudo", ["kill", "-0", String(pid)], {
+  const rc = await exec("sudo", ["-n", "kill", "-0", String(pid)], {
     ignoreReturnCode: true,
     silent: true
   });

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -25827,6 +25827,7 @@ async function parseExecutedSteps(diagDir) {
 var AUDIT_LOG = "/tmp/cargowall-audit.json";
 var CARGOWALL_LOG = "/tmp/cargowall.log";
 var READY_FILE = "/tmp/cargowall-ready";
+var PID_FILE = "/tmp/cargowall.pid";
 var RESOLV_CONF_BACKUP = "/etc/resolv.conf.cargowall.bak";
 var STARTUP_TIMEOUT = 30;
 var STEP_PLAN_FILE = "/tmp/cargowall-step-plan.json";
@@ -25905,7 +25906,13 @@ async function start() {
   }
   const dnsResult = await detectDnsUpstream(getInput("dns-upstream"));
   const dnsUpstream = dnsResult.primary;
-  const args = ["start", "--github-action", `--dns-upstream=${dnsUpstream}`];
+  const args = [
+    "start",
+    "--github-action",
+    `--dns-upstream=${dnsUpstream}`,
+    `--pidfile=${PID_FILE}`,
+    `--ready-file=${READY_FILE}`
+  ];
   if (auditSummary) {
     args.push(`--audit-log=${AUDIT_LOG}`);
   }
@@ -25988,58 +25995,49 @@ async function start() {
   });
   child2.unref();
   (0, import_fs7.closeSync)(logFd);
-  const pid = child2.pid;
-  if (!pid) {
+  const spawnedPid = child2.pid;
+  if (!spawnedPid) {
     throw new Error("Failed to start cargowall process");
   }
-  info(`CargoWall started with PID: ${pid}`);
-  setOutput("pid", pid);
+  info(`CargoWall launcher started (PID: ${spawnedPid})`);
   info("Waiting for cargowall to initialize...");
+  let cargowallPid = null;
+  let ready = false;
   for (let i = 0; i < STARTUP_TIMEOUT; i++) {
     try {
       await import_fs6.promises.access(READY_FILE);
-      info("CargoWall is ready");
+      ready = true;
       break;
     } catch {
     }
-    const killCheck = await exec("sudo", ["kill", "-0", String(pid)], {
-      ignoreReturnCode: true,
-      silent: true
-    });
-    if (killCheck !== 0) {
+    cargowallPid = cargowallPid ?? await readPidFile();
+    if (cargowallPid !== null && !await isProcessAlive(cargowallPid)) {
       error("CargoWall process exited unexpectedly");
       await showLastLog();
-      if (failOnUnsupported) {
-        endGroup();
-        throw new Error("CargoWall failed to start");
-      }
-      warning("CargoWall failed to start. Network filtering is not active.");
-      setOutput("supported", "false");
-      await restoreDns();
-      endGroup();
-      return { supported: false, pid: null };
+      return handleStartupFailure(
+        "CargoWall failed to start. Network filtering is not active.",
+        "CargoWall failed to start",
+        failOnUnsupported
+      );
     }
     await sleep2(1e3);
   }
-  try {
-    await import_fs6.promises.access(READY_FILE);
-  } catch {
+  if (!ready) {
     error("Timeout waiting for cargowall to be ready");
     await showLastLog();
-    await exec("sudo", ["kill", String(pid)], { ignoreReturnCode: true, silent: true });
-    if (failOnUnsupported) {
-      endGroup();
-      throw new Error("CargoWall timed out starting up");
-    }
-    warning("CargoWall timed out. Network filtering is not active.");
-    setOutput("supported", "false");
-    await restoreDns();
-    endGroup();
-    return { supported: false, pid: null };
+    await stopCargowall([cargowallPid ?? await readPidFile(), spawnedPid]);
+    return handleStartupFailure(
+      "CargoWall timed out. Network filtering is not active.",
+      "CargoWall timed out starting up",
+      failOnUnsupported
+    );
   }
+  info("CargoWall is ready");
+  cargowallPid = cargowallPid ?? await readPidFile();
+  const reportedPid = cargowallPid ?? spawnedPid;
   setOutput("supported", "true");
-  saveState("cargowall-pid", String(pid));
-  await import_fs6.promises.writeFile("/tmp/cargowall.pid", String(pid));
+  setOutput("pid", reportedPid);
+  saveState("cargowall-pid", String(reportedPid));
   endGroup();
   notice("CargoWall firewall is active. Network egress is being filtered.");
   if (debug2) {
@@ -26050,7 +26048,44 @@ async function start() {
     }
     endGroup();
   }
-  return { supported: true, pid };
+  return { supported: true, pid: reportedPid };
+}
+async function isProcessAlive(pid) {
+  const rc = await exec("sudo", ["kill", "-0", String(pid)], {
+    ignoreReturnCode: true,
+    silent: true
+  });
+  return rc === 0;
+}
+async function readPidFile() {
+  let out = "";
+  const rc = await exec("sudo", ["cat", PID_FILE], {
+    ignoreReturnCode: true,
+    silent: true,
+    listeners: { stdout: (data) => {
+      out += data.toString();
+    } }
+  });
+  if (rc !== 0) return null;
+  const pid = parseInt(out.trim(), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+async function stopCargowall(pids) {
+  for (const pid of pids) {
+    if (pid == null) continue;
+    await exec("sudo", ["kill", String(pid)], { ignoreReturnCode: true, silent: true });
+  }
+}
+async function handleStartupFailure(warnMessage, throwMessage, failOnUnsupported) {
+  if (failOnUnsupported) {
+    endGroup();
+    throw new Error(throwMessage);
+  }
+  warning(warnMessage);
+  setOutput("supported", "false");
+  await restoreDns();
+  endGroup();
+  return { supported: false, pid: null };
 }
 async function restoreDns() {
   try {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -26085,13 +26085,13 @@ async function stopCargowall(pids) {
   }
 }
 async function handleStartupFailure(warnMessage, throwMessage, failOnUnsupported) {
+  await restoreDns();
   if (failOnUnsupported) {
     endGroup();
     throw new Error(throwMessage);
   }
   warning(warnMessage);
   setOutput("supported", "false");
-  await restoreDns();
   endGroup();
   return { supported: false, pid: null };
 }

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -26012,7 +26012,7 @@ async function start() {
     } catch {
     }
     cargowallPid = cargowallPid ?? await readPidFile();
-    if (cargowallPid !== null && !await isProcessAlive(cargowallPid)) {
+    if (cargowallPid !== null && await processLiveness(cargowallPid) === "dead") {
       error("CargoWall process exited unexpectedly");
       await showLastLog();
       return handleStartupFailure(
@@ -26034,7 +26034,6 @@ async function start() {
     );
   }
   info("CargoWall is ready");
-  await makePidFileReadable();
   cargowallPid = cargowallPid ?? await readPidFile();
   const reportedPid = cargowallPid ?? spawnedPid;
   setOutput("supported", "true");
@@ -26052,7 +26051,12 @@ async function start() {
   }
   return { supported: true, pid: reportedPid };
 }
-async function isProcessAlive(pid) {
+async function processLiveness(pid) {
+  if (await sudoKillZero(pid)) return "alive";
+  if (!await sudoKillZero(1)) return "unknown";
+  return "dead";
+}
+async function sudoKillZero(pid) {
   const rc = await exec("sudo", ["kill", "-0", String(pid)], {
     ignoreReturnCode: true,
     silent: true
@@ -26060,26 +26064,16 @@ async function isProcessAlive(pid) {
   return rc === 0;
 }
 async function readPidFile() {
-  let out = "";
-  const rc = await exec("sudo", ["cat", PID_FILE], {
-    ignoreReturnCode: true,
-    silent: true,
-    listeners: { stdout: (data) => {
-      out += data.toString();
-    } }
-  });
-  if (rc !== 0) return null;
-  const pid = parseInt(out.trim(), 10);
-  return Number.isInteger(pid) && pid > 0 ? pid : null;
+  try {
+    const out = await import_fs6.promises.readFile(PID_FILE, "utf8");
+    const pid = parseInt(out.trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
 }
 async function clearStartupFiles() {
   await exec("sudo", ["rm", "-f", READY_FILE, PID_FILE], {
-    ignoreReturnCode: true,
-    silent: true
-  });
-}
-async function makePidFileReadable() {
-  await exec("sudo", ["chmod", "644", PID_FILE], {
     ignoreReturnCode: true,
     silent: true
   });

--- a/examples/secure.yml
+++ b/examples/secure.yml
@@ -80,10 +80,12 @@ jobs:
       - name: Verify kill is restricted
         run: |
           CARGOWALL_PID=$(cat /tmp/cargowall.pid 2>/dev/null || echo "")
-          if [ -n "$CARGOWALL_PID" ]; then
-            if sudo kill -9 "$CARGOWALL_PID" 2>/dev/null; then
-              echo "ERROR: Should not be able to kill cargowall"
-              exit 1
-            fi
-            echo "Correctly prevented killing cargowall"
+          if [ -z "$CARGOWALL_PID" ]; then
+            echo "ERROR: /tmp/cargowall.pid is empty or unreadable"
+            exit 1
           fi
+          if sudo kill -9 "$CARGOWALL_PID" 2>/dev/null; then
+            echo "ERROR: Should not be able to kill cargowall"
+            exit 1
+          fi
+          echo "Correctly prevented killing cargowall"

--- a/src/start.ts
+++ b/src/start.ts
@@ -386,20 +386,23 @@ async function stopCargowall(pids: Array<number | null>): Promise<void> {
 
 /**
  * Shared handling for a failed/timed-out startup: either throw (when
- * fail-on-unsupported) or warn, mark unsupported, and restore DNS.
+ * fail-on-unsupported) or warn and mark unsupported. Always restore DNS first —
+ * resolv.conf was repointed at 127.0.0.1 (cargowall's proxy) during startup, and
+ * cargowall isn't running, so leaving it would break DNS for subsequent jobs on
+ * a reused/self-hosted runner. Must happen on the throw path too.
  */
 async function handleStartupFailure(
   warnMessage: string,
   throwMessage: string,
   failOnUnsupported: boolean,
 ): Promise<{ supported: boolean; pid: number | null }> {
+  await restoreDns()
   if (failOnUnsupported) {
     core.endGroup()
     throw new Error(throwMessage)
   }
   core.warning(warnMessage)
   core.setOutput('supported', 'false')
-  await restoreDns()
   core.endGroup()
   return { supported: false, pid: null }
 }

--- a/src/start.ts
+++ b/src/start.ts
@@ -338,9 +338,15 @@ async function processLiveness(pid: number): Promise<Liveness> {
   return 'dead'
 }
 
-/** `sudo kill -0 <pid>` — true when it exits 0 (process exists and is signalable). */
+/**
+ * `sudo -n kill -0 <pid>` — true when it exits 0 (process exists and is
+ * signalable). `-n` (non-interactive) is essential: this runs every loop
+ * iteration, and under --sudo-lockdown a non-allowed `sudo` would otherwise
+ * prompt for a password and hang on the action's empty stdin. With `-n` it
+ * fails fast instead, which processLiveness reads as "can't tell" (PID 1 probe).
+ */
 async function sudoKillZero(pid: number): Promise<boolean> {
-  const rc = await exec.exec('sudo', ['kill', '-0', String(pid)], {
+  const rc = await exec.exec('sudo', ['-n', 'kill', '-0', String(pid)], {
     ignoreReturnCode: true,
     silent: true,
   })

--- a/src/start.ts
+++ b/src/start.ts
@@ -11,6 +11,7 @@ import { findDiagDir, parseExecutedSteps, parseJobPlan } from './diag'
 const AUDIT_LOG = '/tmp/cargowall-audit.json'
 const CARGOWALL_LOG = '/tmp/cargowall.log'
 const READY_FILE = '/tmp/cargowall-ready'
+const PID_FILE = '/tmp/cargowall.pid'
 const RESOLV_CONF_BACKUP = '/etc/resolv.conf.cargowall.bak'
 const STARTUP_TIMEOUT = 30
 const STEP_PLAN_FILE = '/tmp/cargowall-step-plan.json'
@@ -110,8 +111,18 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   const dnsResult = await detectDnsUpstream(core.getInput('dns-upstream'))
   const dnsUpstream = dnsResult.primary
 
-  // Build cargowall arguments
-  const args: string[] = ['start', '--github-action', `--dns-upstream=${dnsUpstream}`]
+  // Build cargowall arguments.
+  // --pidfile lets cargowall record its own (real) PID so we can track the
+  // actual process rather than the `sudo` wrapper we spawn. --ready-file is
+  // passed explicitly so the sentinel path stays pinned even if the binary's
+  // default changes.
+  const args: string[] = [
+    'start',
+    '--github-action',
+    `--dns-upstream=${dnsUpstream}`,
+    `--pidfile=${PID_FILE}`,
+    `--ready-file=${READY_FILE}`,
+  ]
 
   if (auditSummary) {
     args.push(`--audit-log=${AUDIT_LOG}`)
@@ -218,83 +229,73 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   child.unref()
   closeSync(logFd)
 
-  const pid = child.pid
-  if (!pid) {
+  const spawnedPid = child.pid
+  if (!spawnedPid) {
     throw new Error('Failed to start cargowall process')
   }
 
-  core.info(`CargoWall started with PID: ${pid}`)
-  core.setOutput('pid', pid)
+  core.info(`CargoWall launcher started (PID: ${spawnedPid})`)
 
-  // Wait for cargowall to be ready
+  // Wait for cargowall to be ready.
+  //
+  // Liveness is intentionally NOT based on the spawned `sudo` wrapper PID: under
+  // the --github-action preset cargowall restarts the Docker daemon during
+  // startup (to apply container DNS config), which tears down and re-parents the
+  // process tree we launched. Polling that PID yields false "exited" verdicts even
+  // though cargowall comes up and filters fine. Instead we wait for the ready
+  // sentinel and, once cargowall has written its own pidfile (just before the
+  // sentinel), use that real PID — a dead real PID is a genuine crash.
   core.info('Waiting for cargowall to initialize...')
 
+  let cargowallPid: number | null = null
+  let ready = false
   for (let i = 0; i < STARTUP_TIMEOUT; i++) {
     try {
       await fs.access(READY_FILE)
-      core.info('CargoWall is ready')
+      ready = true
       break
     } catch {
       // Not ready yet
     }
 
-    // Check if process is still running
-    const killCheck = await exec.exec('sudo', ['kill', '-0', String(pid)], {
-      ignoreReturnCode: true,
-      silent: true
-    })
-    if (killCheck !== 0) {
+    cargowallPid = cargowallPid ?? await readPidFile()
+    if (cargowallPid !== null && !(await isProcessAlive(cargowallPid))) {
       core.error('CargoWall process exited unexpectedly')
-
       await showLastLog()
-
-      if (failOnUnsupported) {
-        core.endGroup()
-        throw new Error('CargoWall failed to start')
-      }
-
-      core.warning('CargoWall failed to start. Network filtering is not active.')
-      core.setOutput('supported', 'false')
-
-      // Restore DNS
-      await restoreDns()
-      core.endGroup()
-      return { supported: false, pid: null }
+      return handleStartupFailure(
+        'CargoWall failed to start. Network filtering is not active.',
+        'CargoWall failed to start',
+        failOnUnsupported,
+      )
     }
 
     await sleep(1000)
   }
 
-  // Check if we timed out
-  try {
-    await fs.access(READY_FILE)
-  } catch {
+  if (!ready) {
     core.error('Timeout waiting for cargowall to be ready')
-
     await showLastLog()
-
-    // Kill the process
-    await exec.exec('sudo', ['kill', String(pid)], { ignoreReturnCode: true, silent: true })
-
-    if (failOnUnsupported) {
-      core.endGroup()
-      throw new Error('CargoWall timed out starting up')
-    }
-
-    core.warning('CargoWall timed out. Network filtering is not active.')
-    core.setOutput('supported', 'false')
-    await restoreDns()
-    core.endGroup()
-    return { supported: false, pid: null }
+    await stopCargowall([cargowallPid ?? await readPidFile(), spawnedPid])
+    return handleStartupFailure(
+      'CargoWall timed out. Network filtering is not active.',
+      'CargoWall timed out starting up',
+      failOnUnsupported,
+    )
   }
 
+  core.info('CargoWall is ready')
+
+  // Resolve cargowall's real PID (written via --pidfile, just before the ready
+  // sentinel) for the `pid` output and cleanup state. Fall back to the launcher
+  // PID if the pidfile can't be read.
+  cargowallPid = cargowallPid ?? await readPidFile()
+  const reportedPid = cargowallPid ?? spawnedPid
+
   core.setOutput('supported', 'true')
+  core.setOutput('pid', reportedPid)
 
-  // Save PID for cleanup via state (persists to post step)
-  core.saveState('cargowall-pid', String(pid))
-
-  // Also write PID file for compatibility
-  await fs.writeFile('/tmp/cargowall.pid', String(pid))
+  // Persist for the post step (also signals that cargowall was started).
+  core.saveState('cargowall-pid', String(reportedPid))
 
   core.endGroup()
 
@@ -309,7 +310,61 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
     core.endGroup()
   }
 
-  return { supported: true, pid }
+  return { supported: true, pid: reportedPid }
+}
+
+/** True if `pid` is alive. Uses sudo since cargowall runs as root. */
+async function isProcessAlive(pid: number): Promise<boolean> {
+  const rc = await exec.exec('sudo', ['kill', '-0', String(pid)], {
+    ignoreReturnCode: true,
+    silent: true,
+  })
+  return rc === 0
+}
+
+/**
+ * Read cargowall's real PID from the pidfile it writes via --pidfile. The file
+ * is owned by root, so we read it through sudo. Returns null if absent/unreadable
+ * (e.g. cargowall hasn't reached the pidfile write yet).
+ */
+async function readPidFile(): Promise<number | null> {
+  let out = ''
+  const rc = await exec.exec('sudo', ['cat', PID_FILE], {
+    ignoreReturnCode: true,
+    silent: true,
+    listeners: { stdout: (data: Buffer) => { out += data.toString() } },
+  })
+  if (rc !== 0) return null
+  const pid = parseInt(out.trim(), 10)
+  return Number.isInteger(pid) && pid > 0 ? pid : null
+}
+
+/** Best-effort SIGTERM to cargowall (real PID and/or launcher PID). */
+async function stopCargowall(pids: Array<number | null>): Promise<void> {
+  for (const pid of pids) {
+    if (pid == null) continue
+    await exec.exec('sudo', ['kill', String(pid)], { ignoreReturnCode: true, silent: true })
+  }
+}
+
+/**
+ * Shared handling for a failed/timed-out startup: either throw (when
+ * fail-on-unsupported) or warn, mark unsupported, and restore DNS.
+ */
+async function handleStartupFailure(
+  warnMessage: string,
+  throwMessage: string,
+  failOnUnsupported: boolean,
+): Promise<{ supported: boolean; pid: number | null }> {
+  if (failOnUnsupported) {
+    core.endGroup()
+    throw new Error(throwMessage)
+  }
+  core.warning(warnMessage)
+  core.setOutput('supported', 'false')
+  await restoreDns()
+  core.endGroup()
+  return { supported: false, pid: null }
 }
 
 async function restoreDns(): Promise<void> {

--- a/src/start.ts
+++ b/src/start.ts
@@ -209,6 +209,12 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   // Start cargowall in the background
   core.info('Starting cargowall...')
 
+  // Clear any stale ready/pid files from a prior run on a reused (e.g.
+  // self-hosted) runner. Otherwise a leftover ready sentinel would short-circuit
+  // the wait, and a stale pidfile pointing at a dead PID would trip the liveness
+  // check as a false "exited unexpectedly". Best-effort and root-owned, so sudo.
+  await clearStartupFiles()
+
   // Set environment variables for cargowall
   const env = {
     ...process.env,
@@ -285,6 +291,11 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
 
   core.info('CargoWall is ready')
 
+  // cargowall writes the pidfile as root. Make it world-readable so unprivileged
+  // workflow steps can `cat /tmp/cargowall.pid` (e.g. examples/secure.yml) — this
+  // preserves the readability of the action-written pidfile prior to v1.3.0.
+  await makePidFileReadable()
+
   // Resolve cargowall's real PID (written via --pidfile, just before the ready
   // sentinel) for the `pid` output and cleanup state. Fall back to the launcher
   // PID if the pidfile can't be read.
@@ -337,6 +348,29 @@ async function readPidFile(): Promise<number | null> {
   if (rc !== 0) return null
   const pid = parseInt(out.trim(), 10)
   return Number.isInteger(pid) && pid > 0 ? pid : null
+}
+
+/**
+ * Best-effort removal of stale ready/pid files left by a prior run in the same
+ * (reused) runner, so this launch's readiness/liveness checks only react to files
+ * this cargowall writes. The files may be root-owned, so remove via sudo.
+ */
+async function clearStartupFiles(): Promise<void> {
+  await exec.exec('sudo', ['rm', '-f', READY_FILE, PID_FILE], {
+    ignoreReturnCode: true,
+    silent: true,
+  })
+}
+
+/**
+ * Best-effort: make the root-owned pidfile world-readable so unprivileged
+ * workflow steps can read it. Non-fatal if the file is absent or chmod fails.
+ */
+async function makePidFileReadable(): Promise<void> {
+  await exec.exec('sudo', ['chmod', '644', PID_FILE], {
+    ignoreReturnCode: true,
+    silent: true,
+  })
 }
 
 /** Best-effort SIGTERM to cargowall (real PID and/or launcher PID). */

--- a/src/start.ts
+++ b/src/start.ts
@@ -250,7 +250,9 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   // process tree we launched. Polling that PID yields false "exited" verdicts even
   // though cargowall comes up and filters fine. Instead we wait for the ready
   // sentinel and, once cargowall has written its own pidfile (just before the
-  // sentinel), use that real PID — a dead real PID is a genuine crash.
+  // sentinel), use that real PID — a dead real PID is a genuine crash. Under
+  // --sudo-lockdown liveness is unobservable (sudo is denied), so we just wait
+  // for the sentinel/timeout rather than risk a false crash verdict.
   core.info('Waiting for cargowall to initialize...')
 
   let cargowallPid: number | null = null
@@ -265,7 +267,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
     }
 
     cargowallPid = cargowallPid ?? await readPidFile()
-    if (cargowallPid !== null && !(await isProcessAlive(cargowallPid))) {
+    if (cargowallPid !== null && (await processLiveness(cargowallPid)) === 'dead') {
       core.error('CargoWall process exited unexpectedly')
       await showLastLog()
       return handleStartupFailure(
@@ -290,11 +292,6 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   }
 
   core.info('CargoWall is ready')
-
-  // cargowall writes the pidfile as root. Make it world-readable so unprivileged
-  // workflow steps can `cat /tmp/cargowall.pid` (e.g. examples/secure.yml) — this
-  // preserves the readability of the action-written pidfile prior to v1.3.0.
-  await makePidFileReadable()
 
   // Resolve cargowall's real PID (written via --pidfile, just before the ready
   // sentinel) for the `pid` output and cleanup state. Fall back to the launcher
@@ -324,8 +321,25 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   return { supported: true, pid: reportedPid }
 }
 
-/** True if `pid` is alive. Uses sudo since cargowall runs as root. */
-async function isProcessAlive(pid: number): Promise<boolean> {
+type Liveness = 'alive' | 'dead' | 'unknown'
+
+/**
+ * Liveness of a root-owned PID. An unprivileged `kill -0` of a root process
+ * returns EPERM even while it's alive, so the check needs sudo. Under
+ * --sudo-lockdown the action's sudo is denied — we then can't observe liveness
+ * at all and must return 'unknown' rather than misreport a crash. PID 1 is the
+ * control: it always exists, so a failing `sudo kill -0 1` means sudo itself is
+ * unavailable (lockdown), not that our process died.
+ */
+async function processLiveness(pid: number): Promise<Liveness> {
+  if (await sudoKillZero(pid)) return 'alive'
+  // The PID check failed: either the process is gone, or sudo is locked down.
+  if (!(await sudoKillZero(1))) return 'unknown'
+  return 'dead'
+}
+
+/** `sudo kill -0 <pid>` — true when it exits 0 (process exists and is signalable). */
+async function sudoKillZero(pid: number): Promise<boolean> {
   const rc = await exec.exec('sudo', ['kill', '-0', String(pid)], {
     ignoreReturnCode: true,
     silent: true,
@@ -334,20 +348,20 @@ async function isProcessAlive(pid: number): Promise<boolean> {
 }
 
 /**
- * Read cargowall's real PID from the pidfile it writes via --pidfile. The file
- * is owned by root, so we read it through sudo. Returns null if absent/unreadable
- * (e.g. cargowall hasn't reached the pidfile write yet).
+ * Read cargowall's real PID from the pidfile it writes via --pidfile. cargowall
+ * writes it world-readable (0644), so we read it directly without sudo — which
+ * also means this keeps working under --sudo-lockdown, where the action's sudo
+ * is denied. Returns null if absent/unreadable (e.g. cargowall hasn't reached
+ * the pidfile write yet).
  */
 async function readPidFile(): Promise<number | null> {
-  let out = ''
-  const rc = await exec.exec('sudo', ['cat', PID_FILE], {
-    ignoreReturnCode: true,
-    silent: true,
-    listeners: { stdout: (data: Buffer) => { out += data.toString() } },
-  })
-  if (rc !== 0) return null
-  const pid = parseInt(out.trim(), 10)
-  return Number.isInteger(pid) && pid > 0 ? pid : null
+  try {
+    const out = await fs.readFile(PID_FILE, 'utf8')
+    const pid = parseInt(out.trim(), 10)
+    return Number.isInteger(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -357,17 +371,6 @@ async function readPidFile(): Promise<number | null> {
  */
 async function clearStartupFiles(): Promise<void> {
   await exec.exec('sudo', ['rm', '-f', READY_FILE, PID_FILE], {
-    ignoreReturnCode: true,
-    silent: true,
-  })
-}
-
-/**
- * Best-effort: make the root-owned pidfile world-readable so unprivileged
- * workflow steps can read it. Non-fatal if the file is absent or chmod fails.
- */
-async function makePidFileReadable(): Promise<void> {
-  await exec.exec('sudo', ['chmod', '644', PID_FILE], {
     ignoreReturnCode: true,
     silent: true,
   })


### PR DESCRIPTION
## Problem

On v1.3.0-rc.1, the action emits a false **"CargoWall process exited unexpectedly" / "CargoWall failed to start. Network filtering is not active."** even though cargowall starts and filters the entire job. Seen in `code-cargo/app` ([run](https://github.com/code-cargo/app/actions/runs/26184590412)): the job's post-step log shows continuous `Connection allowed …` entries through job end, and `outputs.supported` was wrongly set to `false`.

## Root cause

`src/start.ts` spawned `sudo -E cargowall start …` and tracked the **`sudo` wrapper PID**, treating its disappearance (`sudo kill -0 <pid>` ≠ 0) as a fatal crash. Under the v1.3.0 `--github-action` preset, cargowall now restarts the Docker daemon during startup (Docker DNS interception) **before** writing the ready sentinel. That restart tears down / re-parents the launched process tree (the cargowall log shows its init sequence twice), so the tracked PID vanishes while cargowall is alive — tripping the liveness check ~2s in. cargowall keeps filtering via its iptables DNS redirect, which is why the run still behaved as firewalled.

This was latent in v1.2.0 too, but the preset's Docker-restart timing makes it fire reliably on v1.3.0.

## Fix (`src/start.ts`)

- Pass `--pidfile` so cargowall records its **own** PID; read it via `sudo cat` (the file is root-owned). Use that real PID for liveness, the `pid` output, and the cleanup state — not the `sudo` wrapper PID.
- Stop treating wrapper-PID churn as failure: only fail fast on a dead PID **once cargowall has written its real pidfile**; otherwise wait for the ready sentinel (or the existing 30s timeout).
- Pass `--ready-file` explicitly to pin the sentinel path.
- Factor the duplicated failure/timeout handling into `handleStartupFailure`.

`cleanup.ts` is unchanged: it intentionally doesn't kill cargowall (the runner VM is destroyed post-job); it only reads `cargowall-pid` as a "was it started" signal, which now carries the real PID.

## Testing

- `npm test` — 47/47 pass; `npm run build` regenerated `dist/` (idempotent → `check-dist` passes).
- The action's own `test.yml` (incl. `Docker DNS Integration`, which exercises the Docker-restart-during-startup path) runs the action via `uses: ./` on live runners.

