### PR TITLE
Update cargowall to v1.3.5-rc.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,18 +341,24 @@ jobs:
           allowed-hosts: |
             *.ubuntu.com
 
-      - name: Test single-label wildcard (archive.ubuntu.com via *.ubuntu.com)
+      # Assert the block BEFORE the allow: running it first means no *.ubuntu.com
+      # IP is allowlisted yet, so a shared Canonical mirror IP can't mask the
+      # block (gb.archive.ubuntu.com resolves into archive.ubuntu.com's IP pool).
+      # The old host here, us.archive.ubuntu.com, was retired by Canonical and
+      # made this pass vacuously — curl failed to resolve it, which looks
+      # identical to a cargowall block.
+      - name: Test 2-labels-deep name blocked (gb.archive.ubuntu.com not matched by *.ubuntu.com)
         run: |
-          curl -sf --max-time 10 https://archive.ubuntu.com > /dev/null
-          echo "Successfully connected to archive.ubuntu.com via *.ubuntu.com"
-
-      - name: Test globstar wildcard (us.archive.ubuntu.com via **.ubuntu.com should fail - not in rules)
-        run: |
-          if curl -sfL --max-time 5 https://us.archive.ubuntu.com > /dev/null 2>&1; then
-            echo "ERROR: us.archive.ubuntu.com should be blocked (*.ubuntu.com only matches 1 label)"
+          if curl -sfL -4 --max-time 5 https://gb.archive.ubuntu.com > /dev/null 2>&1; then
+            echo "ERROR: gb.archive.ubuntu.com should be blocked (*.ubuntu.com only matches 1 label)"
             exit 1
           fi
-          echo "Correctly blocked us.archive.ubuntu.com (*.ubuntu.com does not match 2 labels deep)"
+          echo "Correctly blocked gb.archive.ubuntu.com (*.ubuntu.com does not match 2 labels deep)"
+
+      - name: Test single-label wildcard (archive.ubuntu.com via *.ubuntu.com)
+        run: |
+          curl -sf -4 --connect-timeout 5 --max-time 20 https://archive.ubuntu.com > /dev/null
+          echo "Successfully connected to archive.ubuntu.com via *.ubuntu.com"
 
       - name: Test blocked connection (httpbin.org)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -295,19 +295,42 @@ jobs:
           allowed-hosts: |
             **.ubuntu.com
 
-      - name: Test allowed connection 2 labels deep (gb.archive.ubuntu.com matches **.ubuntu.com)
+      - name: Test 2 labels deep matches **.ubuntu.com (gb.archive.ubuntu.com)
         run: |
-          # us.archive.ubuntu.com was retired by Canonical and no longer resolves;
-          # gb.archive.ubuntu.com is a live 2-label host under ubuntu.com. The -4 +
-          # --connect-timeout flags skip IPv6 happy-eyeballs and fail a blackholed
-          # mirror IP over to the next resolved address instead of burning --max-time.
-          curl -sfL -4 --connect-timeout 5 --max-time 20 https://gb.archive.ubuntu.com > /dev/null
-          echo "Successfully connected to gb.archive.ubuntu.com via **.ubuntu.com wildcard (2 labels deep)"
+          # Assert cargowall's DNS verdict, not an end-to-end connection. Canonical's
+          # archive mirrors round-robin through 185.125.190.0/24, which GitHub's Azure
+          # runners can't reach on :443, and curl does NOT fail over to another A
+          # record on a connect timeout — so gb.archive.ubuntu.com, whose addresses
+          # are entirely in that range, can never complete a TCP handshake here.
+          # With the --github-action preset's DNS query filtering on and no search
+          # domain configured, a matched name is resolved by the proxy and an
+          # unmatched one is REFUSED, so resolution is a precise match signal.
+          # (us.archive.ubuntu.com, the old host, was retired by Canonical.)
+          OUTPUT=$(nslookup gb.archive.ubuntu.com 127.0.0.1 2>&1 || true)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qi "refused"; then
+            echo "ERROR: gb.archive.ubuntu.com (2 labels deep) should match **.ubuntu.com, but was REFUSED"
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -qi "^Name:"; then
+            echo "ERROR: expected gb.archive.ubuntu.com to resolve through the proxy (globstar match), but it did not"
+            exit 1
+          fi
+          echo "**.ubuntu.com matched gb.archive.ubuntu.com (2 labels deep): allowed and resolved"
 
-      - name: Test allowed connection 1 label deep (archive.ubuntu.com matches **.ubuntu.com)
+      - name: Test 1 label deep matches **.ubuntu.com (archive.ubuntu.com)
         run: |
-          curl -sf -4 --connect-timeout 5 --max-time 20 https://archive.ubuntu.com > /dev/null
-          echo "Successfully connected to archive.ubuntu.com via **.ubuntu.com wildcard (1 label deep)"
+          OUTPUT=$(nslookup archive.ubuntu.com 127.0.0.1 2>&1 || true)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qi "refused"; then
+            echo "ERROR: archive.ubuntu.com (1 label deep) should match **.ubuntu.com, but was REFUSED"
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -qi "^Name:"; then
+            echo "ERROR: expected archive.ubuntu.com to resolve through the proxy (globstar match), but it did not"
+            exit 1
+          fi
+          echo "**.ubuntu.com matched archive.ubuntu.com (1 label deep): allowed and resolved"
 
       - name: Test bare domain not matched (ubuntu.com should not match **.ubuntu.com)
         run: |
@@ -341,24 +364,37 @@ jobs:
           allowed-hosts: |
             *.ubuntu.com
 
-      # Assert the block BEFORE the allow: running it first means no *.ubuntu.com
-      # IP is allowlisted yet, so a shared Canonical mirror IP can't mask the
-      # block (gb.archive.ubuntu.com resolves into archive.ubuntu.com's IP pool).
-      # The old host here, us.archive.ubuntu.com, was retired by Canonical and
-      # made this pass vacuously — curl failed to resolve it, which looks
-      # identical to a cargowall block.
-      - name: Test 2-labels-deep name blocked (gb.archive.ubuntu.com not matched by *.ubuntu.com)
+      # Assert cargowall's DNS verdict rather than a connection: with query
+      # filtering on (the --github-action preset) and no search domain, a name not
+      # matched by any rule is REFUSED at the proxy. gb.archive.ubuntu.com is 2
+      # labels deep, so *.ubuntu.com (single label only) must NOT match it. The
+      # verdict avoids a false pass — gb.archive's IPs are all in Canonical's
+      # unreachable 185.125.190.0/24, so a plain curl would "fail to connect" even
+      # if the name were wrongly allowed (the retired us.archive.ubuntu.com passed
+      # this vacuously for the same reason).
+      - name: Test 2-labels-deep name refused (gb.archive.ubuntu.com not matched by *.ubuntu.com)
         run: |
-          if curl -sfL -4 --max-time 5 https://gb.archive.ubuntu.com > /dev/null 2>&1; then
-            echo "ERROR: gb.archive.ubuntu.com should be blocked (*.ubuntu.com only matches 1 label)"
+          OUTPUT=$(nslookup gb.archive.ubuntu.com 127.0.0.1 2>&1 || true)
+          echo "$OUTPUT"
+          if ! echo "$OUTPUT" | grep -qi "refused"; then
+            echo "ERROR: gb.archive.ubuntu.com should be REFUSED (*.ubuntu.com only matches 1 label)"
             exit 1
           fi
-          echo "Correctly blocked gb.archive.ubuntu.com (*.ubuntu.com does not match 2 labels deep)"
+          echo "Correctly refused gb.archive.ubuntu.com (*.ubuntu.com does not match 2 labels deep)"
 
-      - name: Test single-label wildcard (archive.ubuntu.com via *.ubuntu.com)
+      - name: Test single-label wildcard matches (archive.ubuntu.com via *.ubuntu.com)
         run: |
-          curl -sf -4 --connect-timeout 5 --max-time 20 https://archive.ubuntu.com > /dev/null
-          echo "Successfully connected to archive.ubuntu.com via *.ubuntu.com"
+          OUTPUT=$(nslookup archive.ubuntu.com 127.0.0.1 2>&1 || true)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qi "refused"; then
+            echo "ERROR: archive.ubuntu.com should match *.ubuntu.com, but was REFUSED"
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -qi "^Name:"; then
+            echo "ERROR: expected archive.ubuntu.com to resolve through the proxy (*.ubuntu.com match), but it did not"
+            exit 1
+          fi
+          echo "*.ubuntu.com matched archive.ubuntu.com: allowed and resolved"
 
       - name: Test blocked connection (httpbin.org)
         run: |
@@ -390,12 +426,26 @@ jobs:
 
       - name: Test suffix stripping enables rule match (archive.ubuntu.com -> archive)
         run: |
-          # Without search-domains, the bare `archive` rule would NOT cover
-          # archive.ubuntu.com. It connects only because `.ubuntu.com` is stripped
-          # to `archive`, which matches the rule. The -4 + --connect-timeout flags
-          # skip IPv6 happy-eyeballs and fail a blackholed mirror IP over to the
-          # next resolved address instead of burning --max-time on a dead IP.
-          curl -sf -4 --connect-timeout 5 --max-time 20 https://archive.ubuntu.com > /dev/null
+          # This check must stay end-to-end. A name under the .ubuntu.com search
+          # domain that does NOT match a rule is BYPASSED (forwarded and resolved),
+          # so a DNS-only probe can't tell a real `archive` rule match from a bypass
+          # — only a completed connection proves the resolved IPs were allowlisted.
+          # Without search-domains the bare `archive` rule would not cover
+          # archive.ubuntu.com; it connects only because `.ubuntu.com` is stripped
+          # to `archive`, which matches. Canonical's mirrors round-robin through an
+          # 185.125.190.0/24 range these Azure runners can't reach on :443, and curl
+          # does not fail over across A records on a connect timeout, so retry to get
+          # a re-resolution that fronts a reachable (91.189.x) IP; -4 skips the dead
+          # IPv6 path.
+          ok=""
+          for i in 1 2 3 4 5; do
+            if curl -sf -4 --connect-timeout 5 --max-time 15 https://archive.ubuntu.com > /dev/null; then
+              ok=1; break
+            fi
+            echo "attempt $i: archive.ubuntu.com mirror IP unreachable, retrying"
+            sleep 3
+          done
+          [ -n "$ok" ] || { echo "ERROR: archive.ubuntu.com unreachable after retries; suffix-strip match unverified"; exit 1; }
           echo "Connected to archive.ubuntu.com (.ubuntu.com stripped -> matched 'archive' rule)"
 
       - name: Test bypass for an unmatched name under a search domain (forwarded, not refused)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -295,14 +295,18 @@ jobs:
           allowed-hosts: |
             **.ubuntu.com
 
-      - name: Test allowed connection 2 labels deep (us.archive.ubuntu.com matches **.ubuntu.com)
+      - name: Test allowed connection 2 labels deep (gb.archive.ubuntu.com matches **.ubuntu.com)
         run: |
-          curl -sfL --max-time 10 https://us.archive.ubuntu.com > /dev/null
-          echo "Successfully connected to us.archive.ubuntu.com via **.ubuntu.com wildcard (2 labels deep)"
+          # us.archive.ubuntu.com was retired by Canonical and no longer resolves;
+          # gb.archive.ubuntu.com is a live 2-label host under ubuntu.com. The -4 +
+          # --connect-timeout flags skip IPv6 happy-eyeballs and fail a blackholed
+          # mirror IP over to the next resolved address instead of burning --max-time.
+          curl -sfL -4 --connect-timeout 5 --max-time 20 https://gb.archive.ubuntu.com > /dev/null
+          echo "Successfully connected to gb.archive.ubuntu.com via **.ubuntu.com wildcard (2 labels deep)"
 
       - name: Test allowed connection 1 label deep (archive.ubuntu.com matches **.ubuntu.com)
         run: |
-          curl -sf --max-time 10 https://archive.ubuntu.com > /dev/null
+          curl -sf -4 --connect-timeout 5 --max-time 20 https://archive.ubuntu.com > /dev/null
           echo "Successfully connected to archive.ubuntu.com via **.ubuntu.com wildcard (1 label deep)"
 
       - name: Test bare domain not matched (ubuntu.com should not match **.ubuntu.com)
@@ -382,8 +386,10 @@ jobs:
         run: |
           # Without search-domains, the bare `archive` rule would NOT cover
           # archive.ubuntu.com. It connects only because `.ubuntu.com` is stripped
-          # to `archive`, which matches the rule.
-          curl -sf --max-time 10 https://archive.ubuntu.com > /dev/null
+          # to `archive`, which matches the rule. The -4 + --connect-timeout flags
+          # skip IPv6 happy-eyeballs and fail a blackholed mirror IP over to the
+          # next resolved address instead of burning --max-time on a dead IP.
+          curl -sf -4 --connect-timeout 5 --max-time 20 https://archive.ubuntu.com > /dev/null
           echo "Connected to archive.ubuntu.com (.ubuntu.com stripped -> matched 'archive' rule)"
 
       - name: Test bypass for an unmatched name under a search domain (forwarded, not refused)

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21560,7 +21560,7 @@ var import_promises = require("stream/promises");
 var import_promises2 = require("timers/promises");
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.3.4";
+var CARGOWALL_VERSION = "v1.3.5-rc.1";
 var http2 = new HttpClient("cargowall-action");
 async function downloadAsset(url, dest) {
   const attempt = async () => {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'timers/promises'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.3.4'
+const CARGOWALL_VERSION = 'v1.3.5-rc.1'
 
 const http = new HttpClient('cargowall-action')
 


### PR DESCRIPTION
## Summary

Bump the bundled cargowall binary from **v1.3.4 → v1.3.5-rc.1** (`CARGOWALL_VERSION` in `src/setup.ts`, plus the rebuilt `dist/`).

The rest of this PR is CI test-reliability work: the release-candidate run surfaced pre-existing flakiness in the `*.ubuntu.com` wildcard/search-domain tests. **None of it was caused by the version bump** — cargowall's verdicts were correct in every failing job; the red was external test-dependency drift.

## Version bump

- `src/setup.ts`: `CARGOWALL_VERSION = 'v1.3.5-rc.1'`
- `dist/main/index.js` rebuilt to match

## CI test fixes

Two distinct external problems, both in the ubuntu-mirror tests:

1. **Dead host** — `us.archive.ubuntu.com` was retired by Canonical and no longer resolves anywhere. It was used in a should-connect test (hard fail, exit 6) and a should-block test (passing *vacuously* — a resolve failure looks identical to a cargowall block).
2. **Unreachable subnet** — Canonical's archive mirrors round-robin through `185.125.190.0/24`, which GitHub's Azure runners can't reach on :443 (passing jobs connect to the other `91.189.x` subnet). `gb.archive.ubuntu.com` resolves *entirely* into that range, and **curl does not fail over to another A record on a connect timeout** (verified locally), so it can never complete a handshake here.

### Approach

These wildcard tests care whether cargowall's rule *matched*, not whether Canonical's mirror is up. Since the action always runs `--github-action` (DNS query filtering on), in a job with no search domain a matched name **resolves** through the proxy and an unmatched one is **REFUSED** — so `nslookup 127.0.0.1` is a precise, reachability-independent verdict.

| Job | Change |
| --- | --- |
| **Globstar (`**`)** | both allow tests (`gb.archive` 2-deep, `archive` 1-deep) → assert `nslookup` resolves |
| **Mixed Wildcard** | block test (`gb.archive`) → assert `nslookup` REFUSED (also closes a latent false-pass: an unreachable host "fails to connect" even if wrongly *allowed*); allow test → resolves |
| **DNS Search Domains** | kept end-to-end — a *bypassed* name under the search suffix also resolves, so only a completed connection proves allowlisting — wrapped in a retry with `-4` |

The **Single-Label Wildcard (`*`)** job keeps its `*.ubuntu.com` end-to-end curls as the one reachable wildcard-egress path.

## Known residual

The Search Domains suffix-strip test structurally needs a reachable mirror connection (a DNS-only probe can't distinguish a rule match from a search-domain bypass). The retry is a hedge, so this one can still flake rarely; there's no clean alternative since GitHub hosts are auto-allowed by the preset and would confound the rule test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
