### PR TITLE
#69 #71 durability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,10 @@ jobs:
 
       - name: Test allowed connection (api.github.com)
         run: |
-          curl -sf --max-time 10 https://api.github.com > /dev/null
+          # -f omitted on purpose: unauthenticated api.github.com often 403s (per-IP
+          # rate limit shared across hosted runners). Any HTTP response proves the
+          # firewall allowed the connection, which is what this step tests.
+          curl -s --max-time 10 -o /dev/null https://api.github.com
           echo "Successfully connected to api.github.com"
 
       - name: Test blocked connection (example.com)
@@ -92,7 +95,10 @@ jobs:
 
       - name: Test allowed connection (api.github.com)
         run: |
-          curl -sf --max-time 10 https://api.github.com > /dev/null
+          # -f omitted on purpose: unauthenticated api.github.com often 403s (per-IP
+          # rate limit shared across hosted runners). Any HTTP response proves the
+          # firewall allowed the connection, which is what this step tests.
+          curl -s --max-time 10 -o /dev/null https://api.github.com
           echo "Successfully connected to api.github.com"
 
       - name: Test blocked connection (example.com)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -625,3 +625,239 @@ jobs:
           fi
           # DNS must actually resolve again.
           getent hosts github.com
+
+  # --- api-failure-mode (#69) ------------------------------------------------
+  # These run the REAL binary against a local stub API. Unit tests cover the
+  # action's decision logic, but only these catch a flag the pinned cargowall
+  # does not accept — kong exits on an unknown flag, so a rename would pass
+  # every unit test and break every real run.
+
+  test-api-failure-audit-downgrade:
+    name: API failure downgrades to audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Start a policy API stub that always 503s
+        run: |
+          # 503 is a "server" class failure — a genuine outage, so the posture
+          # applies. Backgrounded; the runner VM is destroyed after the job.
+          cat > /tmp/policy-stub.py <<'PY'
+          import http.server, sys
+          status = int(sys.argv[1])
+          class H(http.server.BaseHTTPRequestHandler):
+              def do_GET(self):
+                  self.send_response(status)
+                  self.send_header('Content-Type', 'application/json')
+                  self.end_headers()
+                  self.wfile.write(b'{}')
+              def log_message(self, *a):
+                  pass
+          http.server.HTTPServer(('127.0.0.1', 8099), H).serve_forever()
+          PY
+          nohup python3 /tmp/policy-stub.py 503 > /tmp/policy-stub.log 2>&1 &
+          for _ in $(seq 1 20); do
+            curl -s -o /dev/null http://127.0.0.1:8099/ && break
+            sleep 0.25
+          done
+          curl -s -o /dev/null -w 'stub status: %{http_code}\n' http://127.0.0.1:8099/
+
+      - name: Setup CargoWall
+        id: cargowall
+        uses: ./
+        with:
+          # mode and api-failure-mode both unset: the default posture is audit.
+          api-url: http://127.0.0.1:8099
+          allowed-hosts: |
+            github.com
+            api.github.com
+
+      - name: Assert the run came up and was downgraded to audit
+        run: |
+          test '${{ steps.cargowall.outputs.supported }}' = 'true'
+
+          echo "mode file:"; cat /tmp/cargowall-mode
+          if [ "$(cat /tmp/cargowall-mode)" != "audit" ]; then
+            echo "ERROR: expected effective mode 'audit'"
+            exit 1
+          fi
+
+          echo "downgrade record:"; cat /tmp/cargowall-downgrade
+          grep -q 'CARGO_WALL_DOWNGRADE_TYPE_AUDIT_FALLBACK' /tmp/cargowall-downgrade
+
+          # audit-summary defaults to true here, but the log must exist either
+          # way — see the audit-summary:false assertion below.
+          test -f /tmp/cargowall-audit.json
+
+      - name: Verify audit posture reaches BOTH datapaths
+        run: |
+          # example.com is not in allowed-hosts. In audit mode the eBPF layer
+          # must not block it AND the DNS proxy must not refuse it — the split
+          # that made audit-summary:false look like enforcement.
+          getent hosts example.com
+          curl -sf --max-time 10 https://example.com > /dev/null
+          echo "example.com reachable, as audit mode requires"
+
+  test-api-failure-not-onboarded:
+    name: API 404 does not change posture
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Start a policy API stub that always 404s
+        run: |
+          cat > /tmp/policy-stub.py <<'PY'
+          import http.server, sys
+          status = int(sys.argv[1])
+          class H(http.server.BaseHTTPRequestHandler):
+              def do_GET(self):
+                  self.send_response(status)
+                  self.send_header('Content-Type', 'application/json')
+                  self.end_headers()
+                  self.wfile.write(b'{}')
+              def log_message(self, *a):
+                  pass
+          http.server.HTTPServer(('127.0.0.1', 8099), H).serve_forever()
+          PY
+          nohup python3 /tmp/policy-stub.py 404 > /tmp/policy-stub.log 2>&1 &
+          for _ in $(seq 1 20); do
+            curl -s -o /dev/null http://127.0.0.1:8099/ && break
+            sleep 0.25
+          done
+
+      - name: Setup CargoWall
+        id: cargowall
+        uses: ./
+        with:
+          # Explicitly asking for the audit downgrade — it must STILL not fire,
+          # because a 404 means "not onboarded", not "the API is down". This is
+          # what keeps the audit default safe for everyone without an account.
+          api-failure-mode: audit
+          api-url: http://127.0.0.1:8099
+          allowed-hosts: |
+            github.com
+            api.github.com
+
+      - name: Assert enforcement is intact
+        run: |
+          test '${{ steps.cargowall.outputs.supported }}' = 'true'
+
+          if [ -f /tmp/cargowall-downgrade ]; then
+            echo "ERROR: a 404 must not produce a downgrade record"
+            cat /tmp/cargowall-downgrade
+            exit 1
+          fi
+
+          curl -sf --max-time 10 https://github.com > /dev/null
+          echo "github.com still allowed"
+
+          if curl -sf --max-time 5 https://example.com > /dev/null 2>&1; then
+            echo "ERROR: example.com should still be blocked — posture was downgraded on an authoritative 404"
+            exit 1
+          fi
+          echo "example.com still blocked, as enforcement requires"
+
+  test-api-failure-lockdown:
+    name: api-failure-mode fail locks down and fails the step
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Start a policy API stub that always 503s
+        run: |
+          cat > /tmp/policy-stub.py <<'PY'
+          import http.server, sys
+          status = int(sys.argv[1])
+          class H(http.server.BaseHTTPRequestHandler):
+              def do_GET(self):
+                  self.send_response(status)
+                  self.send_header('Content-Type', 'application/json')
+                  self.end_headers()
+                  self.wfile.write(b'{}')
+              def log_message(self, *a):
+                  pass
+          http.server.HTTPServer(('127.0.0.1', 8099), H).serve_forever()
+          PY
+          nohup python3 /tmp/policy-stub.py 503 > /tmp/policy-stub.log 2>&1 &
+          for _ in $(seq 1 20); do
+            curl -s -o /dev/null http://127.0.0.1:8099/ && break
+            sleep 0.25
+          done
+
+      - name: Setup CargoWall (expected to fail)
+        id: cargowall
+        continue-on-error: true
+        uses: ./
+        with:
+          api-failure-mode: fail
+          api-url: http://127.0.0.1:8099
+          # fail-on-unsupported is deliberately left at its default (false):
+          # api-failure-mode: fail must fail the step regardless of it.
+          allowed-hosts: |
+            github.com
+            api.github.com
+
+      - name: Assert lockdown was reported promptly
+        run: |
+          if [ '${{ steps.cargowall.outcome }}' != 'failure' ]; then
+            echo "ERROR: expected the action to fail, got '${{ steps.cargowall.outcome }}'"
+            exit 1
+          fi
+
+          # The failure sentinel is what makes this immediate rather than a
+          # 30-second readiness timeout.
+          echo "failure sentinel:"; cat /tmp/cargowall-failed
+          grep -q 'policy lockdown' /tmp/cargowall-failed
+
+          # Ready is withheld on purpose: "ready" means the requested policy is
+          # enforced, and it is not.
+          if [ -f /tmp/cargowall-ready ]; then
+            echo "ERROR: ready sentinel must be withheld in lockdown"
+            exit 1
+          fi
+
+  test-audit-summary-false-still-collects:
+    name: audit-summary false still collects events (#71)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup CargoWall with the summary disabled
+        id: cargowall
+        uses: ./
+        with:
+          offline: 'true'
+          audit-summary: 'false'
+          allowed-hosts: |
+            github.com
+            api.github.com
+
+      - name: Generate some traffic
+        run: curl -sf --max-time 10 https://github.com > /dev/null
+
+      - name: Assert events are still collected
+        run: |
+          test '${{ steps.cargowall.outputs.supported }}' = 'true'
+          # audit-summary controls RENDERING only. Gating collection on it left
+          # these jobs with no events and no dashboard record at all.
+          if [ ! -s /tmp/cargowall-audit.json ]; then
+            echo "ERROR: audit log missing or empty with audit-summary: false"
+            ls -l /tmp/cargowall-audit.json || true
+            exit 1
+          fi
+          echo "audit log has $(wc -l < /tmp/cargowall-audit.json) events"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,41 @@ Run in audit mode to log connections without blocking them — useful for unders
     mode: audit
 ```
 
+### When the CodeCargo Policy Can't Be Fetched
+
+If you manage policies on the [CodeCargo platform](#codecargo-platform), the action fetches the resolved policy at startup. `api-failure-mode` decides what happens when that fetch genuinely fails:
+
+```yaml
+- uses: code-cargo/cargowall-action@v1
+  with:
+    api-failure-mode: audit   # default
+```
+
+| Value              | Behaviour on a retrieval failure                                                              |
+|--------------------|-----------------------------------------------------------------------------------------------|
+| `audit` *(default)* | Run in audit mode — log connections, block nothing. A policy outage never breaks the build, and never silently enforces a config nobody reviewed |
+| `enforce`           | Use this step's own configuration as-is (the behaviour before this input existed)              |
+| `fail`              | Lock the runner down to deny-all and fail the step                                             |
+
+**Only genuine retrieval failures count**: the API being unreachable, a server error, a timeout, or a policy that can't be parsed. These do *not* count and always fall back to this step's configuration, whatever `api-failure-mode` says:
+
+* the repository is not onboarded to CodeCargo (the everyday case for anyone without an account)
+* the OIDC token was rejected, or the workflow is missing `permissions: id-token: write`
+* the repository is marked inactive
+
+That distinction is what makes `audit` safe as a default — without it, every workflow without a CodeCargo account would silently stop enforcing.
+
+**An explicit `mode` wins over the default.** If you wrote `mode: enforce` yourself, a fetch failure leaves you enforcing rather than downgrading you to audit — you asked for enforcement in so many words. Setting `api-failure-mode` explicitly overrides that:
+
+| `mode`     | `api-failure-mode` | Posture on a retrieval failure |
+|------------|--------------------|--------------------------------|
+| unset      | unset              | audit                          |
+| `enforce`  | unset              | enforce (your config)          |
+| `enforce`  | `audit`            | audit                          |
+| any        | `fail`             | deny-all lockdown, step fails  |
+
+This input has no effect when `offline: true` or `api-url` is empty.
+
 ### With Sudo Lockdown (Maximum Security)
 
 Enable sudo lockdown to prevent subsequent steps from disabling the firewall:
@@ -212,10 +247,11 @@ For complex configurations, use a JSON or YAML config file:
 | `allow-existing-connections` | Allow pre-existing TCP connections at startup                                                                                                                                                                                                                                          | `true`                                         |
 | `binary-path`                | Path to a pre-built cargowall binary (skips download)                                                                                                                                                                                                                                  |                                                |
 | `debug`                      | Enable debug logging                                                                                                                                                                                                                                                                   | `false`                                        |
-| `audit-summary`              | Generate audit summary in workflow summary                                                                                                                                                                                                                                             | `true`                                         |
+| `audit-summary`              | Render the audit summary into the workflow run summary. **Rendering only** — event collection and the CodeCargo API push happen either way; use `offline: true` to stop API communication                                                                                               | `true`                                         |
 | `skip-actions-api`           | Skip the GitHub Actions API call that enriches audit-summary step names/status (falls back to local `_diag` data); set `true` when near the per-repo rate limit                                                                                                                        | `false`                                        |
 | `github-token`               | GitHub token for fetching step timing in the audit summary                                                                                                                                                                                                                             | `${{ github.token }}`                          |
 | `api-url`                    | CodeCargo API URL for audit upload and policy fetch (policy requires GitHub App)                                                                                                                                                                                                       | `https://app.codecargo.com`                    |
+| `api-failure-mode`           | Posture when the policy can't be retrieved from the CodeCargo API: `audit`, `enforce`, or `fail`. Only genuine retrieval failures act on it. See [When the CodeCargo Policy Can't Be Fetched](#when-the-codecargo-policy-cant-be-fetched)                                               | `audit` (`enforce` if `mode` is set)           |
 | `offline`                    | Skip all CodeCargo API communication (audit upload and policy fetch)                                                                                                                                                                                                                   | `false`                                        |
 | `job-id`                     | Check run ID of the current job (from workflow context by default; override if needed)                                                                                                                                                                                                 | `${{ job.check_run_id }}`                      |
 

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
       Only genuine retrieval failures act on this — an unreachable API, a server
       error, or an unusable policy. A repository that is not onboarded to
       CodeCargo, a rejected token, or an inactive repository always falls back
-      to this step''s configuration regardless of this setting.
+      to this step's configuration regardless of this setting.
       Ignored when `offline: true` or `api-url` is empty.
       Default: audit, except when `mode` is explicitly set (see README)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,29 @@ branding:
 
 inputs:
   mode:
-    description: 'Enforcement mode: "enforce" (block connections) or "audit" (log only, no blocking)'
+    # Deliberately no `default:` — the runner materialises defaults into INPUT_*
+    # exactly like caller-supplied values, so declaring one here would make an
+    # explicit `mode: enforce` indistinguishable from the default. start.ts
+    # applies the default instead, which lets `api-failure-mode` respect a mode
+    # the caller actually asked for. Keep the default documented here.
+    description: 'Enforcement mode: "enforce" (block connections) or "audit" (log only, no blocking). Default: enforce'
     required: false
-    default: 'enforce'
+  api-failure-mode:
+    # No `default:` for the same reason as `mode` above: an explicitly supplied
+    # value must win over an explicitly supplied `mode`, which needs the two
+    # apart. start.ts defaults this to "audit".
+    description: >-
+      Posture when the policy cannot be retrieved from the CodeCargo API:
+      "audit" (downgrade to audit mode so a policy outage cannot silently drop enforcement to an unreviewed local config),
+      "enforce" (use the policy from this step as-is), or
+      "fail" (lock the runner down to deny-all and fail the step).
+      Only genuine retrieval failures act on this — an unreachable API, a server
+      error, or an unusable policy. A repository that is not onboarded to
+      CodeCargo, a rejected token, or an inactive repository always falls back
+      to this step''s configuration regardless of this setting.
+      Ignored when `offline: true` or `api-url` is empty.
+      Default: audit, except when `mode` is explicitly set (see README)
+    required: false
   allowed-hosts:
     description: 'Allowed hostnames, one per line (auto matches subdomains example.com would also match api.example.com)'
     required: false
@@ -62,7 +82,7 @@ inputs:
     description: 'Enable debug logging'
     default: 'false'
   audit-summary:
-    description: 'Generate audit summary in workflow summary (requires mode: audit or enforce)'
+    description: 'Render the audit summary into the workflow run summary. Rendering only — event collection and the CodeCargo API push happen regardless (use `offline: true` to stop API communication)'
     default: 'true'
   skip-actions-api:
     description: 'Skip the GitHub Actions API call used to enrich audit-summary step names and job status. Falls back to local _diag data. Set to true on installations near the per-repo rate limit (1,000 req/hr).'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -25853,6 +25853,7 @@ ${logOutput}`);
 }
 async function start() {
   const modeInput = getInput("mode");
+  const modeSupplied = VALID_MODES.includes(modeInput);
   let mode = modeInput || "enforce";
   if (!VALID_MODES.includes(mode)) {
     warning(`Invalid mode "${mode}" \u2014 expected "enforce" or "audit". Defaulting to "enforce".`);
@@ -25947,7 +25948,7 @@ async function start() {
     args.push(`--job-key=${context2.job}`);
     const apiFailure = resolveApiFailureMode({
       input: getInput("api-failure-mode"),
-      modeSupplied: modeInput !== ""
+      modeSupplied
     });
     args.push(`--api-failure-mode=${apiFailure.value}`);
     apiFailureLabel = `${apiFailure.value} (${apiFailure.reason})`;

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21560,7 +21560,7 @@ var import_promises = require("stream/promises");
 var import_promises2 = require("timers/promises");
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.3.6-rc.2";
+var CARGOWALL_VERSION = "v1.3.6-rc.3";
 var http2 = new HttpClient("cargowall-action");
 async function downloadAsset(url, dest) {
   const attempt = async () => {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21560,7 +21560,7 @@ var import_promises = require("stream/promises");
 var import_promises2 = require("timers/promises");
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
-var CARGOWALL_VERSION = "v1.3.5";
+var CARGOWALL_VERSION = "v1.3.6-rc.2";
 var http2 = new HttpClient("cargowall-action");
 async function downloadAsset(url, dest) {
   const attempt = async () => {
@@ -25828,6 +25828,8 @@ var AUDIT_LOG = "/tmp/cargowall-audit.json";
 var CARGOWALL_LOG = "/tmp/cargowall.log";
 var READY_FILE = "/tmp/cargowall-ready";
 var PID_FILE = "/tmp/cargowall.pid";
+var FAILURE_FILE = "/tmp/cargowall-failed";
+var DOWNGRADE_FILE = "/tmp/cargowall-downgrade";
 var RESOLV_CONF_BACKUP = "/etc/resolv.conf.cargowall.bak";
 var STARTUP_TIMEOUT = 30;
 var STEP_PLAN_FILE = "/tmp/cargowall-step-plan.json";
@@ -25850,7 +25852,8 @@ ${logOutput}`);
   }
 }
 async function start() {
-  let mode = getInput("mode") || "enforce";
+  const modeInput = getInput("mode");
+  let mode = modeInput || "enforce";
   if (!VALID_MODES.includes(mode)) {
     warning(`Invalid mode "${mode}" \u2014 expected "enforce" or "audit". Defaulting to "enforce".`);
     mode = "enforce";
@@ -25865,7 +25868,6 @@ async function start() {
   const debug2 = getInput("debug") === "true";
   const failOnUnsupported = getInput("fail-on-unsupported") === "true";
   const allowExistingConnections = getInput("allow-existing-connections") !== "false";
-  const auditSummary = getInput("audit-summary") !== "false";
   startGroup("Starting CargoWall Firewall");
   try {
     const diagDir = await findDiagDir();
@@ -25911,11 +25913,15 @@ async function start() {
     "--github-action",
     `--dns-upstream=${dnsUpstream}`,
     `--pidfile=${PID_FILE}`,
-    `--ready-file=${READY_FILE}`
+    `--ready-file=${READY_FILE}`,
+    `--failure-file=${FAILURE_FILE}`,
+    // Always collected. `audit-summary` decides whether the summary is
+    // *rendered* into the workflow run summary, not whether events exist:
+    // the audit log also feeds the dashboard's per-step detail, and gating
+    // collection on a rendering preference made audit-summary:false jobs
+    // invisible to the SaaS entirely (#71).
+    `--audit-log=${AUDIT_LOG}`
   ];
-  if (auditSummary) {
-    args.push(`--audit-log=${AUDIT_LOG}`);
-  }
   if (mode === "audit") {
     args.push("--audit-mode");
     notice("CargoWall running in AUDIT MODE - connections logged but NOT blocked");
@@ -25935,18 +25941,28 @@ async function start() {
   }
   const offline = getInput("offline") === "true";
   const apiUrl = getInput("api-url");
+  let apiFailureLabel = null;
   if (apiUrl && !offline) {
     args.push(`--api-url=${apiUrl}`);
     args.push(`--job-key=${context2.job}`);
+    const apiFailure = resolveApiFailureMode({
+      input: getInput("api-failure-mode"),
+      modeSupplied: modeInput !== ""
+    });
+    args.push(`--api-failure-mode=${apiFailure.value}`);
+    apiFailureLabel = `${apiFailure.value} (${apiFailure.reason})`;
     try {
       const idToken = await getIDToken("codecargo");
       args.push(`--token=${idToken}`);
     } catch (error2) {
-      warning(`Failed to get OIDC token for policy fetch: ${error2}. Falling back to env/file config.`);
-      const apiUrlIdx = args.indexOf(`--api-url=${apiUrl}`);
-      if (apiUrlIdx !== -1) args.splice(apiUrlIdx, 1);
-      const jobKeyIdx = args.indexOf(`--job-key=${context2.job}`);
-      if (jobKeyIdx !== -1) args.splice(jobKeyIdx, 1);
+      warning(
+        `Failed to get OIDC token for policy fetch: ${error2}. Ensure the workflow has "permissions: id-token: write". Falling back to this step's configuration (api-failure-mode does not apply).`
+      );
+      for (const flag of ["--api-url", "--job-key", "--api-failure-mode"]) {
+        const idx = args.findIndex((a) => a.startsWith(`${flag}=`));
+        if (idx !== -1) args.splice(idx, 1);
+      }
+      apiFailureLabel = null;
     }
   }
   if (configFile) {
@@ -25964,6 +25980,7 @@ async function start() {
   if (jobId) info(`  Job run ID: ${jobId}`);
   info(`  Sudo lockdown: ${sudoLockdown}`);
   info(`  DNS upstream: ${dnsUpstream}`);
+  if (apiFailureLabel) info(`  Policy-fetch failure posture: ${apiFailureLabel}`);
   try {
     await import_fs6.promises.access("/etc/resolv.conf");
     await exec("sudo", ["cp", "/etc/resolv.conf", RESOLV_CONF_BACKUP]);
@@ -26013,6 +26030,19 @@ async function start() {
       break;
     } catch {
     }
+    const failureReason = await readFailureFile();
+    if (failureReason !== null) {
+      await showLastLog();
+      if (await isPolicyLockdown()) {
+        return handlePolicyLockdown(failureReason);
+      }
+      error(`CargoWall reported a startup failure: ${failureReason}`);
+      return handleStartupFailure(
+        `CargoWall failed to start. Network filtering is not active. ${failureReason}`,
+        `CargoWall failed to start: ${failureReason}`,
+        failOnUnsupported
+      );
+    }
     cargowallPid = cargowallPid ?? await readPidFile();
     if (cargowallPid !== null && await processLiveness(cargowallPid) === "dead") {
       error("CargoWall process exited unexpectedly");
@@ -26036,6 +26066,7 @@ async function start() {
     );
   }
   info("CargoWall is ready");
+  await warnOnDowngrade();
   cargowallPid = cargowallPid ?? await readPidFile();
   const reportedPid = cargowallPid ?? spawnedPid;
   setOutput("supported", "true");
@@ -26075,10 +26106,43 @@ async function readPidFile() {
   }
 }
 async function clearStartupFiles() {
-  await exec("sudo", ["rm", "-f", READY_FILE, PID_FILE], {
+  await exec("sudo", ["rm", "-f", READY_FILE, PID_FILE, FAILURE_FILE, DOWNGRADE_FILE], {
     ignoreReturnCode: true,
     silent: true
   });
+}
+async function readFailureFile() {
+  try {
+    const reason = (await import_fs6.promises.readFile(FAILURE_FILE, "utf8")).trim();
+    return reason || "cargowall reported a startup failure with no reason recorded";
+  } catch {
+    return null;
+  }
+}
+async function isPolicyLockdown() {
+  await sleep2(250);
+  try {
+    const raw = await import_fs6.promises.readFile(DOWNGRADE_FILE, "utf8");
+    return JSON.parse(raw).type === "CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN";
+  } catch {
+    return false;
+  }
+}
+async function warnOnDowngrade() {
+  let raw;
+  try {
+    raw = await import_fs6.promises.readFile(DOWNGRADE_FILE, "utf8");
+  } catch {
+    return;
+  }
+  try {
+    const detail = JSON.parse(raw).detail;
+    warning(
+      detail ? `CargoWall changed enforcement posture: ${detail}` : `CargoWall changed enforcement posture during startup: ${raw.trim()}`
+    );
+  } catch {
+    warning(`CargoWall changed enforcement posture during startup: ${raw.trim()}`);
+  }
 }
 async function stopCargowall(pids) {
   for (const pid of pids) {
@@ -26097,12 +26161,37 @@ async function handleStartupFailure(warnMessage, throwMessage, failOnUnsupported
   endGroup();
   return { supported: false, pid: null };
 }
+function handlePolicyLockdown(reason) {
+  setOutput("supported", "false");
+  endGroup();
+  throw new Error(
+    `${reason} CargoWall is still running and holding this runner at deny-all, so egress stays blocked for the rest of the job.`
+  );
+}
 async function restoreDns() {
   try {
     await import_fs6.promises.access(RESOLV_CONF_BACKUP);
     await exec("sudo", ["cp", RESOLV_CONF_BACKUP, "/etc/resolv.conf"]);
   } catch {
   }
+}
+function resolveApiFailureMode(args) {
+  const input = args.input.trim().toLowerCase();
+  if (input === "") {
+    return args.modeSupplied ? { value: "local", reason: "default, deferring to the explicitly set `mode`" } : { value: "audit", reason: "default" };
+  }
+  switch (input) {
+    case "audit":
+      return { value: "audit", reason: "set by `api-failure-mode`" };
+    case "enforce":
+    case "local":
+      return { value: "local", reason: "set by `api-failure-mode`" };
+    case "fail":
+      return { value: "fail", reason: "set by `api-failure-mode`" };
+  }
+  throw new Error(
+    `Invalid "api-failure-mode" value "${args.input}" \u2014 expected "audit", "enforce", or "fail".`
+  );
 }
 function requireNonEmptyHostList(name) {
   const hosts = parseList(getMultilineInput(name));

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -26119,30 +26119,40 @@ async function readFailureFile() {
     return null;
   }
 }
-async function isPolicyLockdown() {
-  await sleep2(250);
+async function readDowngradeFile() {
   try {
-    const raw = await import_fs6.promises.readFile(DOWNGRADE_FILE, "utf8");
+    return await import_fs6.promises.readFile(DOWNGRADE_FILE, "utf8");
+  } catch {
+    return null;
+  }
+}
+function isLockdownRecord(raw) {
+  if (raw === null) return false;
+  try {
     return JSON.parse(raw).type === "CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN";
   } catch {
     return false;
   }
 }
+function downgradeMessage(raw) {
+  if (raw === null) return null;
+  let detail;
+  try {
+    detail = JSON.parse(raw).detail;
+  } catch {
+  }
+  if (detail) return `CargoWall changed enforcement posture: ${detail}`;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return `CargoWall changed enforcement posture during startup: ${trimmed}`;
+}
+async function isPolicyLockdown() {
+  await sleep2(250);
+  return isLockdownRecord(await readDowngradeFile());
+}
 async function warnOnDowngrade() {
-  let raw;
-  try {
-    raw = await import_fs6.promises.readFile(DOWNGRADE_FILE, "utf8");
-  } catch {
-    return;
-  }
-  try {
-    const detail = JSON.parse(raw).detail;
-    warning(
-      detail ? `CargoWall changed enforcement posture: ${detail}` : `CargoWall changed enforcement posture during startup: ${raw.trim()}`
-    );
-  } catch {
-    warning(`CargoWall changed enforcement posture during startup: ${raw.trim()}`);
-  }
+  const message = downgradeMessage(await readDowngradeFile());
+  if (message) warning(message);
 }
 async function stopCargowall(pids) {
   for (const pid of pids) {

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -21499,11 +21499,6 @@ function getIDToken(aud) {
   });
 }
 
-// src/audit-push.ts
-async function postAuditResults(_apiUrl) {
-  info("Audit results are now pushed via the cargowall summary command");
-}
-
 // src/cleanup.ts
 var import_fs2 = require("fs");
 var CARGOWALL_LOG = "/tmp/cargowall.log";
@@ -25389,15 +25384,18 @@ function shouldCallActionsApi(args) {
   if (args.skipEnv === "true") return false;
   return true;
 }
-async function generateSummary() {
+async function generateSummary(opts = { render: true }) {
+  const { render } = opts;
+  const offline = getInput("offline") === "true";
+  const apiUrl = getInput("api-url");
+  const canPush = !!apiUrl && !offline;
+  let haveEvents = false;
   try {
-    const stat2 = await import_fs6.promises.stat(AUDIT_LOG);
-    if (stat2.size === 0) {
-      info("Audit log is empty, skipping summary");
-      return;
-    }
+    haveEvents = (await import_fs6.promises.stat(AUDIT_LOG)).size > 0;
   } catch {
-    info("No audit log found, skipping summary");
+  }
+  if (!haveEvents && !canPush) {
+    info("No audit events and no API push configured, skipping summary");
     return;
   }
   startGroup("Generating Audit Summary");
@@ -25475,9 +25473,7 @@ async function generateSummary() {
       currentJobName = context2.job;
     }
     const summaryArgs = ["summary", "--audit-log", AUDIT_LOG, "--steps", stepsJson];
-    const offline = getInput("offline") === "true";
-    const apiUrl = getInput("api-url");
-    if (apiUrl && !offline) {
+    if (canPush) {
       summaryArgs.push("--api-url", apiUrl);
       summaryArgs.push("--job-key", context2.job);
       summaryArgs.push("--job-name", currentJobName);
@@ -25518,34 +25514,42 @@ async function generateSummary() {
         }
       }
     });
-    if (summaryResult === 0 && summaryOutput) {
-      await summary.addRaw(summaryOutput).write();
-      info("Audit summary written to workflow summary");
+    if (summaryResult === 0) {
+      if (render && summaryOutput) {
+        await summary.addRaw(summaryOutput).write();
+        info("Audit summary written to workflow summary");
+      } else {
+        info("Audit summary complete (rendering disabled)");
+      }
     } else {
       warning("Failed to generate audit summary with step correlation");
-      summaryOutput = "";
-      const fallbackResult = await exec("cargowall", ["summary", "--audit-log", AUDIT_LOG, "--steps", "[]"], {
-        ignoreReturnCode: true,
-        listeners: {
-          stdout: (data) => {
-            summaryOutput += data.toString();
+      if (render) {
+        summaryOutput = "";
+        const fallbackResult = await exec("cargowall", ["summary", "--audit-log", AUDIT_LOG, "--steps", "[]"], {
+          ignoreReturnCode: true,
+          listeners: {
+            stdout: (data) => {
+              summaryOutput += data.toString();
+            }
           }
+        });
+        if (fallbackResult === 0 && summaryOutput) {
+          await summary.addRaw(summaryOutput).write();
+          info("Basic audit summary written to workflow summary");
         }
-      });
-      if (fallbackResult === 0 && summaryOutput) {
-        await summary.addRaw(summaryOutput).write();
-        info("Basic audit summary written to workflow summary");
       }
     }
   } catch (error) {
     warning(`Failed to generate audit summary: ${error}`);
   }
-  try {
-    const log = await import_fs6.promises.readFile(CARGOWALL_LOG2, "utf8");
-    if (log) {
-      await summary.addRaw("<details><summary>CargoWall Process Log</summary>\n\n```\n").addRaw(log).addRaw("\n```\n</details>\n").write();
+  if (render) {
+    try {
+      const log = await import_fs6.promises.readFile(CARGOWALL_LOG2, "utf8");
+      if (log) {
+        await summary.addRaw("<details><summary>CargoWall Process Log</summary>\n\n```\n").addRaw(log).addRaw("\n```\n</details>\n").write();
+      }
+    } catch {
     }
-  } catch {
   }
   endGroup();
 }
@@ -25716,13 +25720,12 @@ async function run() {
       info("CargoWall was not started, skipping cleanup");
       return;
     }
-    const auditSummary = getInput("audit-summary") !== "false";
-    if (auditSummary) {
-      await generateSummary();
-    }
-    const apiUrl = getInput("api-url");
-    if (apiUrl) {
-      await postAuditResults(apiUrl);
+    const render = getInput("audit-summary") !== "false";
+    const canPush = !!getInput("api-url") && getInput("offline") !== "true";
+    if (render || canPush) {
+      await generateSummary({ render });
+    } else {
+      info("Audit summary disabled and API push not configured, skipping summary");
     }
     await cleanup();
     info("CargoWall cleanup complete");

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -25513,7 +25513,7 @@ async function generateSummary(opts = { render: true }) {
       ignoreReturnCode: true,
       listeners: {
         stdout: (data) => {
-          summaryOutput += data.toString();
+          if (render) summaryOutput += data.toString();
         }
       }
     });

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -25384,6 +25384,9 @@ function shouldCallActionsApi(args) {
   if (args.skipEnv === "true") return false;
   return true;
 }
+function shouldRunSummary(args) {
+  return args.haveEvents || args.canPush;
+}
 async function generateSummary(opts = { render: true }) {
   const { render } = opts;
   const offline = getInput("offline") === "true";
@@ -25394,7 +25397,7 @@ async function generateSummary(opts = { render: true }) {
     haveEvents = (await import_fs6.promises.stat(AUDIT_LOG)).size > 0;
   } catch {
   }
-  if (!haveEvents && !canPush) {
+  if (!shouldRunSummary({ haveEvents, canPush })) {
     info("No audit events and no API push configured, skipping summary");
     return;
   }

--- a/src/audit-push.ts
+++ b/src/audit-push.ts
@@ -1,8 +1,0 @@
-import * as core from '@actions/core'
-
-// The Go `cargowall summary` binary now handles pushing audit results to the API
-// as part of summary generation. This function is kept as a no-op for backwards
-// compatibility with post.ts which calls it.
-export async function postAuditResults(_apiUrl: string): Promise<void> {
-  core.info('Audit results are now pushed via the cargowall summary command')
-}

--- a/src/post.test.ts
+++ b/src/post.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * #71: `audit-summary` must gate *rendering only*. `cargowall summary` is also
+ * the SaaS push, so skipping the invocation made those jobs invisible to the
+ * dashboard — no job record, no effective mode, no downgrade record.
+ */
+
+vi.mock('@actions/core', () => ({
+  getInput: vi.fn(),
+  getState: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+}))
+vi.mock('./cleanup', () => ({ cleanup: vi.fn() }))
+vi.mock('./summary', () => ({ generateSummary: vi.fn() }))
+
+import * as core from '@actions/core'
+import { cleanup } from './cleanup'
+import { generateSummary } from './summary'
+
+/** post.ts invokes run() on import, so re-import it fresh to drive each path. */
+async function runPost(): Promise<void> {
+  vi.resetModules()
+  await import('./post')
+  await vi.waitFor(() => {
+    expect(vi.mocked(cleanup)).toHaveBeenCalled()
+  })
+}
+
+function withInputs(inputs: Record<string, string>): void {
+  vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '')
+}
+
+describe('post', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // cargowall started, so the post step does its full job.
+    vi.mocked(core.getState).mockImplementation((name: string) =>
+      name === 'cargowall-pid' ? '4242' : ''
+    )
+    withInputs({})
+  })
+
+  it('renders and pushes by default', async () => {
+    withInputs({ 'api-url': 'https://app.codecargo.com' })
+    await runPost()
+    expect(generateSummary).toHaveBeenCalledWith({ render: true })
+  })
+
+  it('still runs the summary with audit-summary:false when the API is configured', async () => {
+    withInputs({ 'audit-summary': 'false', 'api-url': 'https://app.codecargo.com' })
+
+    await runPost()
+
+    // The push lives inside this invocation — skipping it is the #71 bug.
+    expect(generateSummary).toHaveBeenCalledWith({ render: false })
+  })
+
+  it('renders when audit-summary is on even with no API configured', async () => {
+    withInputs({ 'api-url': '' })
+    await runPost()
+    expect(generateSummary).toHaveBeenCalledWith({ render: true })
+  })
+
+  it('skips entirely when there is nothing to render and nothing to push', async () => {
+    withInputs({ 'audit-summary': 'false', 'api-url': '' })
+    await runPost()
+    expect(generateSummary).not.toHaveBeenCalled()
+  })
+
+  it('treats offline as nothing to push, so audit-summary:false skips entirely', async () => {
+    withInputs({
+      'audit-summary': 'false',
+      'api-url': 'https://app.codecargo.com',
+      offline: 'true',
+    })
+
+    await runPost()
+
+    expect(generateSummary).not.toHaveBeenCalled()
+  })
+
+  it('still pushes when offline is set to anything other than the literal "true"', async () => {
+    withInputs({
+      'audit-summary': 'false',
+      'api-url': 'https://app.codecargo.com',
+      offline: 'false',
+    })
+
+    await runPost()
+
+    expect(generateSummary).toHaveBeenCalledWith({ render: false })
+  })
+
+  it('does nothing when cargowall was never started', async () => {
+    vi.mocked(core.getState).mockImplementation((name: string) =>
+      name === 'cargowall-skipped' ? 'true' : ''
+    )
+    withInputs({ 'api-url': 'https://app.codecargo.com' })
+
+    vi.resetModules()
+    await import('./post')
+    await vi.waitFor(() => expect(core.info).toHaveBeenCalled())
+
+    expect(generateSummary).not.toHaveBeenCalled()
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+})

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core'
-import { postAuditResults } from './audit-push'
 import { cleanup } from './cleanup'
 import { generateSummary } from './summary'
 
@@ -14,17 +13,20 @@ async function run(): Promise<void> {
       return
     }
 
-    // Generate summary FIRST while cargowall is still running
-    // (audit log is synced to disk after every write)
-    const auditSummary = core.getInput('audit-summary') !== 'false'
-    if (auditSummary) {
-      await generateSummary()
-    }
-
-    // Push audit results to CodeCargo API if configured
-    const apiUrl = core.getInput('api-url')
-    if (apiUrl) {
-      await postAuditResults(apiUrl)
+    // Run the summary FIRST while cargowall is still running
+    // (audit log is synced to disk after every write).
+    //
+    // `cargowall summary` both renders the markdown and performs the SaaS push,
+    // so `audit-summary` may only suppress the rendering — gating the whole
+    // invocation on it made those jobs invisible to the dashboard, downgrade
+    // records included (#71). Skip entirely only when there is nothing to do:
+    // no rendering wanted and no API to push to.
+    const render = core.getInput('audit-summary') !== 'false'
+    const canPush = !!core.getInput('api-url') && core.getInput('offline') !== 'true'
+    if (render || canPush) {
+      await generateSummary({ render })
+    } else {
+      core.info('Audit summary disabled and API push not configured, skipping summary')
     }
 
     // Minimal cleanup — VM destruction handles the rest

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'timers/promises'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.3.6-rc.2'
+const CARGOWALL_VERSION = 'v1.3.6-rc.3'
 
 const http = new HttpClient('cargowall-action')
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from 'timers/promises'
 
 const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
-const CARGOWALL_VERSION = 'v1.3.5'
+const CARGOWALL_VERSION = 'v1.3.6-rc.2'
 
 const http = new HttpClient('cargowall-action')
 

--- a/src/start.spawn.test.ts
+++ b/src/start.spawn.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * Covers the arguments `start()` actually hands the cargowall binary.
+ *
+ * This is the regression surface for both #69 (policy-fetch posture) and #71
+ * (audit-summary must not gate event collection): the resolution logic is unit
+ * tested elsewhere, but nothing else proves the resolved value reaches the
+ * command line, or that a flag dropped on one path is dropped on all of them.
+ *
+ * Lives in its own file because it needs the whole module graph mocked, while
+ * start.test.ts deliberately mocks only `getMultilineInput`.
+ */
+
+vi.mock('@actions/core', () => ({
+  getInput: vi.fn(),
+  getMultilineInput: vi.fn(() => []),
+  getIDToken: vi.fn(),
+  startGroup: vi.fn(),
+  endGroup: vi.fn(),
+  info: vi.fn(),
+  notice: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  saveState: vi.fn(),
+  setOutput: vi.fn(),
+}))
+vi.mock('@actions/exec', () => ({ exec: vi.fn(async () => 0) }))
+vi.mock('@actions/github', () => ({ context: { job: 'build' } }))
+vi.mock('./dns', () => ({
+  detectDnsUpstream: vi.fn(async () => ({ primary: '10.0.0.1:53' })),
+}))
+// No _diag dir → no watcher spawn, so the only spawn() call is cargowall itself.
+vi.mock('./diag', () => ({
+  findDiagDir: vi.fn(async () => null),
+  parseJobPlan: vi.fn(async () => ({})),
+  parseExecutedSteps: vi.fn(async () => []),
+}))
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 4242, unref: vi.fn() })),
+}))
+vi.mock('fs', () => ({
+  openSync: vi.fn(() => 3),
+  closeSync: vi.fn(),
+  promises: {
+    access: vi.fn(async () => undefined),
+    readFile: vi.fn(async () => { throw new Error('ENOENT') }),
+    writeFile: vi.fn(async () => undefined),
+  },
+}))
+
+import * as core from '@actions/core'
+import { promises as fsp } from 'fs'
+import { spawn } from 'child_process'
+import { start } from './start'
+
+const READY_FILE = '/tmp/cargowall-ready'
+const FAILURE_FILE = '/tmp/cargowall-failed'
+const DOWNGRADE_FILE = '/tmp/cargowall-downgrade'
+
+/**
+ * Model the state files cargowall writes. `absent` paths make fs.access reject
+ * and fs.readFile throw, matching how the wait loop actually probes them.
+ */
+function withFiles(files: Record<string, string>): void {
+  vi.mocked(fsp.access).mockImplementation(async (p: unknown) => {
+    if (String(p) in files || !String(p).startsWith('/tmp/cargowall')) return undefined
+    throw new Error(`ENOENT: ${String(p)}`)
+  })
+  vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
+    const content = files[String(p)]
+    if (content === undefined) throw new Error(`ENOENT: ${String(p)}`)
+    return content
+  })
+}
+
+/**
+ * The two auto-allow host lists carry non-empty defaults in action.yml, which
+ * the runner materialises for us — requireNonEmptyHostList treats an empty
+ * result as a deliberate clear and throws. Mirror the runner so tests exercise
+ * the real path rather than that guard.
+ */
+const HOST_LIST_DEFAULTS: Record<string, string[]> = {
+  'github-service-hosts': ['github.com', 'api.github.com'],
+  'azure-infra-hosts': ['trafficmanager.net'],
+}
+
+/** Inputs not named by a test fall back to '' — i.e. "caller said nothing". */
+function withInputs(inputs: Record<string, string>): void {
+  vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '')
+}
+
+/** The argv handed to the cargowall binary (spawn is `sudo -E cargowall …`). */
+async function cargowallArgs(): Promise<string[]> {
+  await start()
+  const call = vi.mocked(spawn).mock.calls.at(-1)
+  if (!call) throw new Error('cargowall was never spawned')
+  return call[1] as string[]
+}
+
+/** Value of a `--flag=value` argument, or undefined when the flag is absent. */
+function flag(args: string[], name: string): string | undefined {
+  return args.find(a => a.startsWith(`${name}=`))?.slice(name.length + 1)
+}
+
+describe('start() argument construction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(core.getMultilineInput).mockImplementation(
+      (name: string) => HOST_LIST_DEFAULTS[name] ?? []
+    )
+    vi.mocked(core.getIDToken).mockResolvedValue('oidc-token')
+    vi.mocked(core.getInput).mockReturnValue('')
+    // Ready sentinel already present, so the wait loop exits on iteration 0.
+    withFiles({ [READY_FILE]: '' })
+  })
+
+  describe('audit log collection (#71)', () => {
+    it('passes --audit-log even when audit-summary is false', async () => {
+      withInputs({ 'audit-summary': 'false' })
+      // Gating collection on a rendering preference is exactly the bug: it left
+      // audit-summary:false jobs with no events and no dashboard record.
+      expect(flag(await cargowallArgs(), '--audit-log')).toBe('/tmp/cargowall-audit.json')
+    })
+
+    it('passes --audit-log when audit-summary is left at its default', async () => {
+      withInputs({})
+      expect(flag(await cargowallArgs(), '--audit-log')).toBe('/tmp/cargowall-audit.json')
+    })
+  })
+
+  describe('failure sentinel', () => {
+    it('pins --failure-file so the wait loop and the binary agree on the path', async () => {
+      withInputs({})
+      expect(flag(await cargowallArgs(), '--failure-file')).toBe('/tmp/cargowall-failed')
+    })
+  })
+
+  describe('--api-failure-mode (#69)', () => {
+    it('defaults to audit when neither mode nor api-failure-mode is given', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com' })
+      expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('audit')
+    })
+
+    it('defers to an explicitly set mode', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', mode: 'enforce' })
+      expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('local')
+    })
+
+    it('translates the public "enforce" spelling to cargowall\'s "local"', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', 'api-failure-mode': 'enforce' })
+      expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('local')
+    })
+
+    it('passes fail through', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', 'api-failure-mode': 'fail' })
+      expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('fail')
+    })
+
+    it('lets an explicit api-failure-mode beat an explicit mode', async () => {
+      withInputs({
+        'api-url': 'https://app.codecargo.com',
+        mode: 'enforce',
+        'api-failure-mode': 'audit',
+      })
+      expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('audit')
+    })
+
+    it('omits the flag entirely when offline', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', offline: 'true' })
+      const args = await cargowallArgs()
+      expect(flag(args, '--api-failure-mode')).toBeUndefined()
+      expect(flag(args, '--api-url')).toBeUndefined()
+    })
+
+    it('omits the flag entirely when no api-url is configured', async () => {
+      withInputs({ 'api-url': '' })
+      expect(flag(await cargowallArgs(), '--api-failure-mode')).toBeUndefined()
+    })
+
+    it('drops the flag with the rest of the API args when the OIDC token is unavailable', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', 'api-failure-mode': 'fail' })
+      vi.mocked(core.getIDToken).mockRejectedValue(new Error('no id-token permission'))
+
+      const args = await cargowallArgs()
+
+      // No token means no fetch is attempted, so there is no retrieval failure
+      // to act on. Leaving --api-failure-mode=fail behind would lock the runner
+      // down over a missing workflow permission.
+      expect(flag(args, '--api-failure-mode')).toBeUndefined()
+      expect(flag(args, '--api-url')).toBeUndefined()
+      expect(flag(args, '--job-key')).toBeUndefined()
+      expect(flag(args, '--token')).toBeUndefined()
+    })
+
+    it('fails the step on an invalid value instead of picking a posture', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', 'api-failure-mode': 'abort' })
+      await expect(start()).rejects.toThrow(/Invalid "api-failure-mode" value "abort"/)
+    })
+  })
+
+  describe('mode', () => {
+    it('passes --audit-mode when mode is audit', async () => {
+      withInputs({ mode: 'audit' })
+      expect(await cargowallArgs()).toContain('--audit-mode')
+    })
+
+    it('omits --audit-mode by default, since the default is enforce', async () => {
+      withInputs({})
+      expect(await cargowallArgs()).not.toContain('--audit-mode')
+    })
+  })
+
+  describe('posture downgrade reporting', () => {
+    it('warns when cargowall recorded an audit fallback', async () => {
+      withInputs({})
+      withFiles({
+        [READY_FILE]: '',
+        [DOWNGRADE_FILE]: JSON.stringify({
+          type: 'CARGO_WALL_DOWNGRADE_TYPE_AUDIT_FALLBACK',
+          detail: 'downgraded to audit mode: policy could not be retrieved',
+        }),
+      })
+
+      await start()
+
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('downgraded to audit mode: policy could not be retrieved')
+      )
+    })
+
+    it('stays quiet on a normal run', async () => {
+      withInputs({})
+      await start()
+      expect(core.warning).not.toHaveBeenCalled()
+    })
+  })
+})
+
+/**
+ * The failure sentinel is shared by policy lockdown and any fatal startup
+ * error, and the two need opposite handling. Getting this wrong either fails
+ * builds that `fail-on-unsupported: false` says to warn-and-continue on, or
+ * lets a lockdown pass as a success.
+ */
+describe('start() failure-sentinel handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(core.getMultilineInput).mockImplementation(
+      (name: string) => HOST_LIST_DEFAULTS[name] ?? []
+    )
+    vi.mocked(core.getIDToken).mockResolvedValue('oidc-token')
+    vi.mocked(core.getInput).mockReturnValue('')
+  })
+
+  it('fails the step on policy lockdown, even with fail-on-unsupported false', async () => {
+    withInputs({ 'fail-on-unsupported': 'false' })
+    withFiles({
+      // No ready sentinel: in lockdown cargowall deliberately withholds it.
+      [FAILURE_FILE]: 'cargowall entered policy lockdown (default-deny): policy fetch failed',
+      [DOWNGRADE_FILE]: JSON.stringify({ type: 'CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN' }),
+    })
+
+    // fail-on-unsupported is about eBPF support; api-failure-mode: fail is an
+    // explicit request to fail the build, so it must not be overridden by it.
+    await expect(start()).rejects.toThrow(/policy lockdown/)
+  })
+
+  it('says the runner is still locked down, so the failure is actionable', async () => {
+    withInputs({})
+    withFiles({
+      [FAILURE_FILE]: 'cargowall entered policy lockdown (default-deny): policy fetch failed',
+      [DOWNGRADE_FILE]: JSON.stringify({ type: 'CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN' }),
+    })
+
+    await expect(start()).rejects.toThrow(/holding this runner at deny-all/)
+  })
+
+  it('honours fail-on-unsupported:false for a generic fatal startup error', async () => {
+    withInputs({ 'fail-on-unsupported': 'false' })
+    withFiles({ [FAILURE_FILE]: 'cargowall startup failed: failed to attach TC program' })
+
+    // No downgrade record → not a lockdown → the pre-existing contract applies.
+    const result = await start()
+
+    expect(result).toEqual({ supported: false, pid: null })
+    expect(core.setOutput).toHaveBeenCalledWith('supported', 'false')
+    // Pins this to the sentinel branch: the 30s-timeout path returns the same
+    // shape, but carries a generic message instead of the binary's reason.
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('failed to attach TC program')
+    )
+  })
+
+  it('fails a generic fatal startup error when fail-on-unsupported is true', async () => {
+    withInputs({ 'fail-on-unsupported': 'true' })
+    withFiles({ [FAILURE_FILE]: 'cargowall startup failed: failed to attach TC program' })
+
+    await expect(start()).rejects.toThrow(/failed to attach TC program/)
+  })
+
+  it('surfaces the binary\'s own reason rather than a generic message', async () => {
+    withInputs({ 'fail-on-unsupported': 'true' })
+    withFiles({ [FAILURE_FILE]: 'cargowall startup failed: interface eth0 not found' })
+
+    await expect(start()).rejects.toThrow(/interface eth0 not found/)
+  })
+})

--- a/src/start.spawn.test.ts
+++ b/src/start.spawn.test.ts
@@ -147,6 +147,18 @@ describe('start() argument construction', () => {
       expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('local')
     })
 
+    it('does not treat an invalid mode as explicitly set', async () => {
+      withInputs({ 'api-url': 'https://app.codecargo.com', mode: 'bogus' })
+
+      const args = await cargowallArgs()
+
+      // A typo'd mode falls back to enforce as a lenient recovery, not a user
+      // instruction — so the audit default must still apply on API outages.
+      expect(flag(args, '--api-failure-mode')).toBe('audit')
+      expect(args).not.toContain('--audit-mode')
+      expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('Invalid mode "bogus"'))
+    })
+
     it('translates the public "enforce" spelling to cargowall\'s "local"', async () => {
       withInputs({ 'api-url': 'https://app.codecargo.com', 'api-failure-mode': 'enforce' })
       expect(flag(await cargowallArgs(), '--api-failure-mode')).toBe('local')

--- a/src/start.test.ts
+++ b/src/start.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { requireNonEmptyHostList } from './start'
+import { requireNonEmptyHostList, resolveApiFailureMode } from './start'
 
 // Mock @actions/core — requireNonEmptyHostList calls core.getMultilineInput
 vi.mock('@actions/core', () => ({
@@ -57,6 +57,46 @@ describe('requireNonEmptyHostList', () => {
     withInput([])
     expect(() => requireNonEmptyHostList('azure-infra-hosts')).toThrow(
       /does not disable the auto-allowed hosts/
+    )
+  })
+})
+
+describe('resolveApiFailureMode', () => {
+  it('defaults to audit so a policy outage cannot silently keep enforcing local config', () => {
+    expect(resolveApiFailureMode({ input: '', modeSupplied: false }).value).toBe('audit')
+  })
+
+  it('defers to an explicitly set mode rather than downgrading it', () => {
+    const r = resolveApiFailureMode({ input: '', modeSupplied: true })
+    expect(r.value).toBe('local')
+    expect(r.reason).toMatch(/explicitly set `mode`/)
+  })
+
+  it('lets an explicit api-failure-mode win over an explicit mode', () => {
+    // Both are explicit, but only api-failure-mode is *about* fetch failures.
+    expect(resolveApiFailureMode({ input: 'audit', modeSupplied: true }).value).toBe('audit')
+    expect(resolveApiFailureMode({ input: 'fail', modeSupplied: true }).value).toBe('fail')
+  })
+
+  it('translates the public "enforce" spelling to cargowall\'s "local"', () => {
+    expect(resolveApiFailureMode({ input: 'enforce', modeSupplied: false }).value).toBe('local')
+  })
+
+  it('accepts "local" as an alias so either vocabulary works', () => {
+    expect(resolveApiFailureMode({ input: 'local', modeSupplied: false }).value).toBe('local')
+  })
+
+  it('passes fail through', () => {
+    expect(resolveApiFailureMode({ input: 'fail', modeSupplied: false }).value).toBe('fail')
+  })
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(resolveApiFailureMode({ input: '  Fail \n', modeSupplied: false }).value).toBe('fail')
+  })
+
+  it('throws on an unrecognised value rather than guessing a posture', () => {
+    expect(() => resolveApiFailureMode({ input: 'abort', modeSupplied: false })).toThrow(
+      /Invalid "api-failure-mode" value "abort"/
     )
   })
 })

--- a/src/start.test.ts
+++ b/src/start.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { requireNonEmptyHostList, resolveApiFailureMode } from './start'
+import {
+  requireNonEmptyHostList,
+  resolveApiFailureMode,
+  isLockdownRecord,
+  downgradeMessage,
+} from './start'
 
 // Mock @actions/core — requireNonEmptyHostList calls core.getMultilineInput
 vi.mock('@actions/core', () => ({
@@ -98,5 +103,65 @@ describe('resolveApiFailureMode', () => {
     expect(() => resolveApiFailureMode({ input: 'abort', modeSupplied: false })).toThrow(
       /Invalid "api-failure-mode" value "abort"/
     )
+  })
+})
+
+/**
+ * The failure sentinel is written for BOTH policy lockdown and any fatal
+ * startup error. Misreading a generic crash as lockdown would fail builds that
+ * `fail-on-unsupported: false` (the default) says to warn-and-continue on, so
+ * everything unrecognised must read as "not lockdown".
+ */
+describe('isLockdownRecord', () => {
+  it('recognises a lockdown downgrade record', () => {
+    expect(isLockdownRecord(JSON.stringify({ type: 'CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN' }))).toBe(true)
+  })
+
+  it('does not treat an audit fallback as lockdown', () => {
+    expect(
+      isLockdownRecord(JSON.stringify({ type: 'CARGO_WALL_DOWNGRADE_TYPE_AUDIT_FALLBACK' }))
+    ).toBe(false)
+  })
+
+  it('treats an absent record as not lockdown — the generic startup-failure path', () => {
+    expect(isLockdownRecord(null)).toBe(false)
+  })
+
+  it('treats unparseable JSON as not lockdown rather than failing the build', () => {
+    expect(isLockdownRecord('{"type": ')).toBe(false)
+  })
+
+  it('treats a record with no type as not lockdown', () => {
+    expect(isLockdownRecord(JSON.stringify({ detail: 'something happened' }))).toBe(false)
+  })
+})
+
+describe('downgradeMessage', () => {
+  it('returns null when no posture change was recorded', () => {
+    expect(downgradeMessage(null)).toBeNull()
+  })
+
+  it('surfaces the human-readable detail', () => {
+    const raw = JSON.stringify({
+      type: 'CARGO_WALL_DOWNGRADE_TYPE_AUDIT_FALLBACK',
+      detail: 'downgraded to audit mode: policy could not be retrieved',
+    })
+    expect(downgradeMessage(raw)).toBe(
+      'CargoWall changed enforcement posture: downgraded to audit mode: policy could not be retrieved'
+    )
+  })
+
+  it('still warns when the record is unparseable — losing the notice is worse than raw JSON', () => {
+    expect(downgradeMessage('{"type":')).toMatch(/changed enforcement posture during startup/)
+  })
+
+  it('still warns when the record parses but carries no detail', () => {
+    expect(downgradeMessage(JSON.stringify({ type: 'CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN' }))).toMatch(
+      /changed enforcement posture during startup/
+    )
+  })
+
+  it('returns null for an empty record rather than warning about nothing', () => {
+    expect(downgradeMessage('   ')).toBeNull()
   })
 })

--- a/src/start.ts
+++ b/src/start.ts
@@ -455,21 +455,29 @@ async function readFailureFile(): Promise<string | null> {
   }
 }
 
+/** Read the downgrade record, or null when cargowall recorded no posture change. */
+async function readDowngradeFile(): Promise<string | null> {
+  try {
+    return await fs.readFile(DOWNGRADE_FILE, 'utf8')
+  } catch {
+    return null
+  }
+}
+
 /**
  * Distinguish the two states behind the failure sentinel: policy lockdown
  * (cargowall alive, holding the runner at deny-all, an explicitly requested
  * outcome) from any other fatal startup error (cargowall gone, filtering
- * absent). They need opposite handling, so classify on the structured
- * downgrade record rather than on the reason text.
+ * absent). They need opposite handling — the first must always fail the step,
+ * the second must keep honouring `fail-on-unsupported` — so classify on the
+ * structured downgrade record rather than on the reason text.
  *
- * Both paths write the sentinel immediately before their next step — the
- * downgrade record on one, process exit on the other — so wait briefly for
- * that adjacent write to land before deciding.
+ * Anything unreadable reads as "not lockdown", which routes to the pre-existing
+ * startup-failure handling rather than newly failing a build.
  */
-async function isPolicyLockdown(): Promise<boolean> {
-  await sleep(250)
+export function isLockdownRecord(raw: string | null): boolean {
+  if (raw === null) return false
   try {
-    const raw = await fs.readFile(DOWNGRADE_FILE, 'utf8')
     return (JSON.parse(raw) as { type?: string }).type === 'CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN'
   } catch {
     return false
@@ -477,28 +485,41 @@ async function isPolicyLockdown(): Promise<boolean> {
 }
 
 /**
- * Report a posture change cargowall recorded during startup. The downgrade file
- * holds a protojson CargoWallDowngrade; we only need its human-readable detail.
- * Best-effort: a run that filtered correctly must not fail over a missing or
- * unparseable reporting artifact.
+ * The human-readable half of a downgrade record. Falls back to the raw payload
+ * so an unparseable record still tells the user their posture changed — losing
+ * that notice is worse than printing JSON at them.
+ */
+export function downgradeMessage(raw: string | null): string | null {
+  if (raw === null) return null
+  let detail: string | undefined
+  try {
+    detail = (JSON.parse(raw) as { detail?: string }).detail
+  } catch {
+    // Fall through to the raw payload.
+  }
+  if (detail) return `CargoWall changed enforcement posture: ${detail}`
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  return `CargoWall changed enforcement posture during startup: ${trimmed}`
+}
+
+/**
+ * Classify a failure sentinel. Both paths write the sentinel immediately before
+ * their next step — the downgrade record on one, process exit on the other — so
+ * wait briefly for that adjacent write to land before deciding.
+ */
+async function isPolicyLockdown(): Promise<boolean> {
+  await sleep(250)
+  return isLockdownRecord(await readDowngradeFile())
+}
+
+/**
+ * Report a posture change cargowall recorded during startup. Best-effort: a run
+ * that filtered correctly must not fail over a reporting artifact.
  */
 async function warnOnDowngrade(): Promise<void> {
-  let raw: string
-  try {
-    raw = await fs.readFile(DOWNGRADE_FILE, 'utf8')
-  } catch {
-    return // No posture change — the common case.
-  }
-  try {
-    const detail = (JSON.parse(raw) as { detail?: string }).detail
-    core.warning(
-      detail
-        ? `CargoWall changed enforcement posture: ${detail}`
-        : `CargoWall changed enforcement posture during startup: ${raw.trim()}`
-    )
-  } catch {
-    core.warning(`CargoWall changed enforcement posture during startup: ${raw.trim()}`)
-  }
+  const message = downgradeMessage(await readDowngradeFile())
+  if (message) core.warning(message)
 }
 
 /** Best-effort SIGTERM to cargowall (real PID and/or launcher PID). */

--- a/src/start.ts
+++ b/src/start.ts
@@ -41,8 +41,12 @@ async function showLastLog(): Promise<void> {
 export async function start(): Promise<{ supported: boolean; pid: number | null }> {
   // `mode` carries no default in action.yml, so an empty value means the caller
   // did not ask for a mode — which is what lets resolveApiFailureMode tell an
-  // explicit `mode: enforce` apart from the default one.
+  // explicit `mode: enforce` apart from the default one. Only a VALID value
+  // counts as supplied: a typo'd mode falls back to enforce as a lenient
+  // recovery, not a user instruction, and treating it as "explicitly asked to
+  // enforce" would also suppress the api-failure-mode audit default.
   const modeInput = core.getInput('mode')
+  const modeSupplied = VALID_MODES.includes(modeInput as typeof VALID_MODES[number])
   let mode = modeInput || 'enforce'
 
   if (!VALID_MODES.includes(mode as typeof VALID_MODES[number])) {
@@ -174,7 +178,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
     args.push(`--job-key=${github.context.job}`)
     const apiFailure = resolveApiFailureMode({
       input: core.getInput('api-failure-mode'),
-      modeSupplied: modeInput !== '',
+      modeSupplied,
     })
     args.push(`--api-failure-mode=${apiFailure.value}`)
     apiFailureLabel = `${apiFailure.value} (${apiFailure.reason})`
@@ -608,7 +612,9 @@ export interface ApiFailureModeResolution {
  *
  * `modeSupplied` is only knowable because `mode` declares no default in
  * action.yml — the runner materialises defaults into INPUT_* indistinguishably
- * from caller-supplied values.
+ * from caller-supplied values. Callers must pass true only for a valid `mode`
+ * value: an invalid one falls back to enforce as a lenient recovery, which is
+ * not an instruction worth deferring to.
  */
 export function resolveApiFailureMode(args: { input: string; modeSupplied: boolean }): ApiFailureModeResolution {
   const input = args.input.trim().toLowerCase()

--- a/src/start.ts
+++ b/src/start.ts
@@ -12,6 +12,12 @@ const AUDIT_LOG = '/tmp/cargowall-audit.json'
 const CARGOWALL_LOG = '/tmp/cargowall.log'
 const READY_FILE = '/tmp/cargowall-ready'
 const PID_FILE = '/tmp/cargowall.pid'
+// FAILURE_FILE is written by cargowall on any fatal startup error, including
+// the policy lockdown from --api-failure-mode=fail. DOWNGRADE_FILE is its
+// structured record of a posture change, and tells those two apart. Both paths
+// are shared with the Go binary — keep them in sync.
+const FAILURE_FILE = '/tmp/cargowall-failed'
+const DOWNGRADE_FILE = '/tmp/cargowall-downgrade'
 const RESOLV_CONF_BACKUP = '/etc/resolv.conf.cargowall.bak'
 const STARTUP_TIMEOUT = 30
 const STEP_PLAN_FILE = '/tmp/cargowall-step-plan.json'
@@ -33,7 +39,11 @@ async function showLastLog(): Promise<void> {
 }
 
 export async function start(): Promise<{ supported: boolean; pid: number | null }> {
-  let mode = core.getInput('mode') || 'enforce'
+  // `mode` carries no default in action.yml, so an empty value means the caller
+  // did not ask for a mode — which is what lets resolveApiFailureMode tell an
+  // explicit `mode: enforce` apart from the default one.
+  const modeInput = core.getInput('mode')
+  let mode = modeInput || 'enforce'
 
   if (!VALID_MODES.includes(mode as typeof VALID_MODES[number])) {
     core.warning(`Invalid mode "${mode}" — expected "enforce" or "audit". Defaulting to "enforce".`)
@@ -50,7 +60,6 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   const debug = core.getInput('debug') === 'true'
   const failOnUnsupported = core.getInput('fail-on-unsupported') === 'true'
   const allowExistingConnections = core.getInput('allow-existing-connections') !== 'false'
-  const auditSummary = core.getInput('audit-summary') !== 'false'
 
   core.startGroup('Starting CargoWall Firewall')
 
@@ -122,11 +131,14 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
     `--dns-upstream=${dnsUpstream}`,
     `--pidfile=${PID_FILE}`,
     `--ready-file=${READY_FILE}`,
+    `--failure-file=${FAILURE_FILE}`,
+    // Always collected. `audit-summary` decides whether the summary is
+    // *rendered* into the workflow run summary, not whether events exist:
+    // the audit log also feeds the dashboard's per-step detail, and gating
+    // collection on a rendering preference made audit-summary:false jobs
+    // invisible to the SaaS entirely (#71).
+    `--audit-log=${AUDIT_LOG}`,
   ]
-
-  if (auditSummary) {
-    args.push(`--audit-log=${AUDIT_LOG}`)
-  }
 
   if (mode === 'audit') {
     args.push('--audit-mode')
@@ -154,19 +166,36 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   // from the CodeCargo SaaS API.
   const offline = core.getInput('offline') === 'true'
   const apiUrl = core.getInput('api-url')
+  // Non-null only while the API flags survive, so the configuration log never
+  // advertises a posture that was dropped along with them below.
+  let apiFailureLabel: string | null = null
   if (apiUrl && !offline) {
     args.push(`--api-url=${apiUrl}`)
     args.push(`--job-key=${github.context.job}`)
+    const apiFailure = resolveApiFailureMode({
+      input: core.getInput('api-failure-mode'),
+      modeSupplied: modeInput !== '',
+    })
+    args.push(`--api-failure-mode=${apiFailure.value}`)
+    apiFailureLabel = `${apiFailure.value} (${apiFailure.reason})`
     try {
       const idToken = await core.getIDToken('codecargo')
       args.push(`--token=${idToken}`)
     } catch (error) {
-      core.warning(`Failed to get OIDC token for policy fetch: ${error}. Falling back to env/file config.`)
-      // Remove api-url and job-key so Go binary uses env/file fallback
-      const apiUrlIdx = args.indexOf(`--api-url=${apiUrl}`)
-      if (apiUrlIdx !== -1) args.splice(apiUrlIdx, 1)
-      const jobKeyIdx = args.indexOf(`--job-key=${github.context.job}`)
-      if (jobKeyIdx !== -1) args.splice(jobKeyIdx, 1)
+      // No token means no fetch is even attempted, so this is not a retrieval
+      // failure and must not trigger the api-failure-mode posture — it is a
+      // workflow misconfiguration, handled the same way cargowall handles a
+      // rejected token. Drop the API flags so the binary uses env/file config.
+      core.warning(
+        `Failed to get OIDC token for policy fetch: ${error}. ` +
+          `Ensure the workflow has "permissions: id-token: write". ` +
+          `Falling back to this step's configuration (api-failure-mode does not apply).`
+      )
+      for (const flag of ['--api-url', '--job-key', '--api-failure-mode']) {
+        const idx = args.findIndex(a => a.startsWith(`${flag}=`))
+        if (idx !== -1) args.splice(idx, 1)
+      }
+      apiFailureLabel = null
     }
   }
 
@@ -187,6 +216,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   if (jobId) core.info(`  Job run ID: ${jobId}`)
   core.info(`  Sudo lockdown: ${sudoLockdown}`)
   core.info(`  DNS upstream: ${dnsUpstream}`)
+  if (apiFailureLabel) core.info(`  Policy-fetch failure posture: ${apiFailureLabel}`)
 
   // Backup current resolv.conf
   try {
@@ -268,6 +298,25 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
       // Not ready yet
     }
 
+    // cargowall reported a startup failure. Two very different situations
+    // share this sentinel — see isPolicyLockdown.
+    const failureReason = await readFailureFile()
+    if (failureReason !== null) {
+      await showLastLog()
+      if (await isPolicyLockdown()) {
+        return handlePolicyLockdown(failureReason)
+      }
+      // A fatal startup error: cargowall has exited. Same contract as the
+      // "exited unexpectedly" branch below — honour fail-on-unsupported —
+      // but with the binary's own reason instead of a guess.
+      core.error(`CargoWall reported a startup failure: ${failureReason}`)
+      return handleStartupFailure(
+        `CargoWall failed to start. Network filtering is not active. ${failureReason}`,
+        `CargoWall failed to start: ${failureReason}`,
+        failOnUnsupported,
+      )
+    }
+
     cargowallPid = cargowallPid ?? await readPidFile()
     if (cargowallPid !== null && (await processLiveness(cargowallPid)) === 'dead') {
       core.error('CargoWall process exited unexpectedly')
@@ -294,6 +343,11 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   }
 
   core.info('CargoWall is ready')
+
+  // Surface a posture change (e.g. --api-failure-mode=audit downgraded the run)
+  // now that startup succeeded. Deliberately after the ready check: a lockdown
+  // exits above, so anything recorded here belongs to a run that came up.
+  await warnOnDowngrade()
 
   // Resolve cargowall's real PID (written via --pidfile, just before the ready
   // sentinel) for the `pid` output and cleanup state. Fall back to the launcher
@@ -378,10 +432,73 @@ async function readPidFile(): Promise<number | null> {
  * this cargowall writes. The files may be root-owned, so remove via sudo.
  */
 async function clearStartupFiles(): Promise<void> {
-  await exec.exec('sudo', ['rm', '-f', READY_FILE, PID_FILE], {
+  await exec.exec('sudo', ['rm', '-f', READY_FILE, PID_FILE, FAILURE_FILE, DOWNGRADE_FILE], {
     ignoreReturnCode: true,
     silent: true,
   })
+}
+
+/**
+ * Read cargowall's failure sentinel. It is written for any fatal startup error,
+ * and also when --api-failure-mode=fail puts the runner into policy lockdown —
+ * the latter is why we poll for it at all: in lockdown cargowall deliberately
+ * withholds the ready sentinel and keeps running deny-all, so the wait loop
+ * would otherwise sit out the full timeout for a decision already made.
+ * Returns the reason, or null if absent.
+ */
+async function readFailureFile(): Promise<string | null> {
+  try {
+    const reason = (await fs.readFile(FAILURE_FILE, 'utf8')).trim()
+    return reason || 'cargowall reported a startup failure with no reason recorded'
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Distinguish the two states behind the failure sentinel: policy lockdown
+ * (cargowall alive, holding the runner at deny-all, an explicitly requested
+ * outcome) from any other fatal startup error (cargowall gone, filtering
+ * absent). They need opposite handling, so classify on the structured
+ * downgrade record rather than on the reason text.
+ *
+ * Both paths write the sentinel immediately before their next step — the
+ * downgrade record on one, process exit on the other — so wait briefly for
+ * that adjacent write to land before deciding.
+ */
+async function isPolicyLockdown(): Promise<boolean> {
+  await sleep(250)
+  try {
+    const raw = await fs.readFile(DOWNGRADE_FILE, 'utf8')
+    return (JSON.parse(raw) as { type?: string }).type === 'CARGO_WALL_DOWNGRADE_TYPE_LOCKDOWN'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Report a posture change cargowall recorded during startup. The downgrade file
+ * holds a protojson CargoWallDowngrade; we only need its human-readable detail.
+ * Best-effort: a run that filtered correctly must not fail over a missing or
+ * unparseable reporting artifact.
+ */
+async function warnOnDowngrade(): Promise<void> {
+  let raw: string
+  try {
+    raw = await fs.readFile(DOWNGRADE_FILE, 'utf8')
+  } catch {
+    return // No posture change — the common case.
+  }
+  try {
+    const detail = (JSON.parse(raw) as { detail?: string }).detail
+    core.warning(
+      detail
+        ? `CargoWall changed enforcement posture: ${detail}`
+        : `CargoWall changed enforcement posture during startup: ${raw.trim()}`
+    )
+  } catch {
+    core.warning(`CargoWall changed enforcement posture during startup: ${raw.trim()}`)
+  }
 }
 
 /** Best-effort SIGTERM to cargowall (real PID and/or launcher PID). */
@@ -415,6 +532,29 @@ async function handleStartupFailure(
   return { supported: false, pid: null }
 }
 
+/**
+ * Handle `--api-failure-mode=fail`: cargowall could not retrieve a policy and
+ * has locked the runner down to deny-all.
+ *
+ * Always throws, regardless of `fail-on-unsupported` — that input is about eBPF
+ * support on the runner, whereas reaching here means the caller explicitly asked
+ * for the build to fail when the policy is unavailable.
+ *
+ * Deliberately does not restore DNS or stop cargowall. The lockdown is meant to
+ * hold for the rest of the job: cargowall is alive and still serving DNS on
+ * 127.0.0.1, so restoring resolv.conf would point name resolution back at the
+ * upstream while eBPF keeps blocking egress — a confusing half-dismantled state
+ * rather than the fail-closed one that was asked for.
+ */
+function handlePolicyLockdown(reason: string): never {
+  core.setOutput('supported', 'false')
+  core.endGroup()
+  throw new Error(
+    `${reason} CargoWall is still running and holding this runner at deny-all, ` +
+      `so egress stays blocked for the rest of the job.`
+  )
+}
+
 async function restoreDns(): Promise<void> {
   try {
     await fs.access(RESOLV_CONF_BACKUP)
@@ -422,6 +562,59 @@ async function restoreDns(): Promise<void> {
   } catch {
     // No backup to restore
   }
+}
+
+/** cargowall's spelling of the three postures, plus how we got there. */
+export interface ApiFailureModeResolution {
+  value: 'audit' | 'local' | 'fail'
+  reason: string
+}
+
+/**
+ * Resolve the `--api-failure-mode` value handed to cargowall.
+ *
+ * The action's vocabulary is `audit | enforce | fail`; the binary calls the
+ * middle one `local`, because "enforce" here means "this step's own policy",
+ * which is *audit* when the step says `mode: audit`. `local` is accepted as an
+ * alias so either vocabulary works in a workflow.
+ *
+ * The default is `audit` — a policy outage should not silently hand the job an
+ * unreviewed local config with full enforcement behind it. But that default
+ * yields to an explicit `mode`: a caller who wrote `mode: enforce` asked for
+ * enforcement in so many words, and downgrading them on an outage would
+ * override an instruction they actually gave. An explicitly supplied
+ * `api-failure-mode` always wins over both.
+ *
+ * `modeSupplied` is only knowable because `mode` declares no default in
+ * action.yml — the runner materialises defaults into INPUT_* indistinguishably
+ * from caller-supplied values.
+ */
+export function resolveApiFailureMode(args: { input: string; modeSupplied: boolean }): ApiFailureModeResolution {
+  const input = args.input.trim().toLowerCase()
+
+  if (input === '') {
+    return args.modeSupplied
+      ? { value: 'local', reason: 'default, deferring to the explicitly set `mode`' }
+      : { value: 'audit', reason: 'default' }
+  }
+
+  switch (input) {
+    case 'audit':
+      return { value: 'audit', reason: 'set by `api-failure-mode`' }
+    case 'enforce':
+    case 'local':
+      return { value: 'local', reason: 'set by `api-failure-mode`' }
+    case 'fail':
+      return { value: 'fail', reason: 'set by `api-failure-mode`' }
+  }
+
+  // Deliberately fatal rather than warn-and-default like `mode`: this input
+  // decides what happens to enforcement during an API outage, and a typo
+  // would otherwise surface as a silent posture change during a rare remote
+  // failure instead of immediately at configuration time.
+  throw new Error(
+    `Invalid "api-failure-mode" value "${args.input}" — expected "audit", "enforce", or "fail".`
+  )
 }
 
 /**

--- a/src/summary.test.ts
+++ b/src/summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { enhanceApiStepsWithDiag, buildStepsFromDiag, shouldCallActionsApi, type DiagData, type StepEntry } from './summary'
+import { enhanceApiStepsWithDiag, buildStepsFromDiag, shouldCallActionsApi, shouldRunSummary, type DiagData, type StepEntry } from './summary'
 
 // Mock @actions/core — buildStepsFromDiag calls core.getState and core.info
 vi.mock('@actions/core', () => ({
@@ -317,5 +317,30 @@ describe('shouldCallActionsApi', () => {
     expect(shouldCallActionsApi({ ...baseArgs, skipInput: '1' })).toBe(true)
     expect(shouldCallActionsApi({ ...baseArgs, skipInput: 'TRUE' })).toBe(true)
     expect(shouldCallActionsApi({ ...baseArgs, skipEnv: 'yes' })).toBe(true)
+  })
+})
+
+/**
+ * The summary invocation is also the SaaS push, so a missing audit log must not
+ * short-circuit it — that early return is what made cargowall's zero-event push
+ * unreachable from the action (#71).
+ */
+describe('shouldRunSummary', () => {
+  it('runs when there are events to render', () => {
+    expect(shouldRunSummary({ haveEvents: true, canPush: false })).toBe(true)
+  })
+
+  it('runs with no events at all when the API is configured', () => {
+    // The zero-event push still carries the job record, effective mode, status,
+    // cargowall version and any downgrade record.
+    expect(shouldRunSummary({ haveEvents: false, canPush: true })).toBe(true)
+  })
+
+  it('runs when both apply', () => {
+    expect(shouldRunSummary({ haveEvents: true, canPush: true })).toBe(true)
+  })
+
+  it('skips only when there is nothing to render and nothing to push', () => {
+    expect(shouldRunSummary({ haveEvents: false, canPush: false })).toBe(false)
   })
 })

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -214,12 +214,13 @@ export async function generateSummary(opts: { render: boolean } = { render: true
       }
     }
 
-    // Run cargowall summary command
+    // Run cargowall summary command. The stdout (the rendered markdown) is
+    // only accumulated when it will be written to the workflow summary.
     let summaryOutput = ''
     const summaryResult = await exec.exec('cargowall', summaryArgs, {
       ignoreReturnCode: true,
       listeners: {
-        stdout: (data: Buffer) => { summaryOutput += data.toString() }
+        stdout: (data: Buffer) => { if (render) summaryOutput += data.toString() }
       }
     })
 

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -30,16 +30,31 @@ export function shouldCallActionsApi(args: {
   return true
 }
 
-export async function generateSummary(): Promise<void> {
-  // Check if audit log exists and has content
+/**
+ * Run `cargowall summary`, which both renders the markdown summary and pushes
+ * the job record to the CodeCargo API.
+ *
+ * `render: false` suppresses only the workflow-summary output — the push still
+ * happens, because the job record, effective mode, job status, cargowall
+ * version and any downgrade record are independent of event collection.
+ */
+export async function generateSummary(opts: { render: boolean } = { render: true }): Promise<void> {
+  const { render } = opts
+  const offline = core.getInput('offline') === 'true'
+  const apiUrl = core.getInput('api-url')
+  const canPush = !!apiUrl && !offline
+
+  // An absent or empty audit log is no longer a reason to bail: the binary
+  // treats it as a zero-event push and still reports the job. Only skip when
+  // there is also nothing to push, since then the run really is a no-op.
+  let haveEvents = false
   try {
-    const stat = await fs.stat(AUDIT_LOG)
-    if (stat.size === 0) {
-      core.info('Audit log is empty, skipping summary')
-      return
-    }
+    haveEvents = (await fs.stat(AUDIT_LOG)).size > 0
   } catch {
-    core.info('No audit log found, skipping summary')
+    // No audit log — cargowall may have been started without one.
+  }
+  if (!haveEvents && !canPush) {
+    core.info('No audit events and no API push configured, skipping summary')
     return
   }
 
@@ -145,9 +160,7 @@ export async function generateSummary(): Promise<void> {
     const summaryArgs = ['summary', '--audit-log', AUDIT_LOG, '--steps', stepsJson]
 
     // Add API push flags if api-url is configured and offline mode is not enabled
-    const offline = core.getInput('offline') === 'true'
-    const apiUrl = core.getInput('api-url')
-    if (apiUrl && !offline) {
+    if (canPush) {
       summaryArgs.push('--api-url', apiUrl)
       summaryArgs.push('--job-key', github.context.job)
       summaryArgs.push('--job-name', currentJobName)
@@ -199,24 +212,34 @@ export async function generateSummary(): Promise<void> {
       }
     })
 
-    if (summaryResult === 0 && summaryOutput) {
-      await core.summary.addRaw(summaryOutput).write()
-      core.info('Audit summary written to workflow summary')
+    if (summaryResult === 0) {
+      // The push (when configured) happened inside that invocation regardless
+      // of whether we render its stdout.
+      if (render && summaryOutput) {
+        await core.summary.addRaw(summaryOutput).write()
+        core.info('Audit summary written to workflow summary')
+      } else {
+        core.info('Audit summary complete (rendering disabled)')
+      }
     } else {
       core.warning('Failed to generate audit summary with step correlation')
 
-      // Fall back to basic summary without step correlation
-      summaryOutput = ''
-      const fallbackResult = await exec.exec('cargowall', ['summary', '--audit-log', AUDIT_LOG, '--steps', '[]'], {
-        ignoreReturnCode: true,
-        listeners: {
-          stdout: (data: Buffer) => { summaryOutput += data.toString() }
-        }
-      })
+      // Fall back to a basic summary without step correlation. Rendering-only:
+      // it carries no API flags, so there is nothing to retry when the summary
+      // is not being rendered.
+      if (render) {
+        summaryOutput = ''
+        const fallbackResult = await exec.exec('cargowall', ['summary', '--audit-log', AUDIT_LOG, '--steps', '[]'], {
+          ignoreReturnCode: true,
+          listeners: {
+            stdout: (data: Buffer) => { summaryOutput += data.toString() }
+          }
+        })
 
-      if (fallbackResult === 0 && summaryOutput) {
-        await core.summary.addRaw(summaryOutput).write()
-        core.info('Basic audit summary written to workflow summary')
+        if (fallbackResult === 0 && summaryOutput) {
+          await core.summary.addRaw(summaryOutput).write()
+          core.info('Basic audit summary written to workflow summary')
+        }
       }
     }
   } catch (error) {
@@ -224,17 +247,19 @@ export async function generateSummary(): Promise<void> {
   }
 
   // Append full cargowall log to summary
-  try {
-    const log = await fs.readFile(CARGOWALL_LOG, 'utf8')
-    if (log) {
-      await core.summary
-        .addRaw('<details><summary>CargoWall Process Log</summary>\n\n```\n')
-        .addRaw(log)
-        .addRaw('\n```\n</details>\n')
-        .write()
+  if (render) {
+    try {
+      const log = await fs.readFile(CARGOWALL_LOG, 'utf8')
+      if (log) {
+        await core.summary
+          .addRaw('<details><summary>CargoWall Process Log</summary>\n\n```\n')
+          .addRaw(log)
+          .addRaw('\n```\n</details>\n')
+          .write()
+      }
+    } catch {
+      // No log file available
     }
-  } catch {
-    // No log file available
   }
 
   // Audit log left in place — cargowall is still running and VM is ephemeral

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -31,6 +31,20 @@ export function shouldCallActionsApi(args: {
 }
 
 /**
+ * Whether `cargowall summary` is worth invoking at all.
+ *
+ * That one invocation does two jobs: it renders the markdown summary AND
+ * performs the CodeCargo push. So an absent or empty audit log is not a reason
+ * to bail — the binary treats it as a zero-event push and still reports the job
+ * record, effective mode, status, version and any downgrade. Skipping on a
+ * missing log is what made `audit-summary: false` jobs invisible to the
+ * dashboard (#71). Only skip when there is genuinely nothing to do.
+ */
+export function shouldRunSummary(args: { haveEvents: boolean; canPush: boolean }): boolean {
+  return args.haveEvents || args.canPush
+}
+
+/**
  * Run `cargowall summary`, which both renders the markdown summary and pushes
  * the job record to the CodeCargo API.
  *
@@ -44,16 +58,13 @@ export async function generateSummary(opts: { render: boolean } = { render: true
   const apiUrl = core.getInput('api-url')
   const canPush = !!apiUrl && !offline
 
-  // An absent or empty audit log is no longer a reason to bail: the binary
-  // treats it as a zero-event push and still reports the job. Only skip when
-  // there is also nothing to push, since then the run really is a no-op.
   let haveEvents = false
   try {
     haveEvents = (await fs.stat(AUDIT_LOG)).size > 0
   } catch {
     // No audit log — cargowall may have been started without one.
   }
-  if (!haveEvents && !canPush) {
+  if (!shouldRunSummary({ haveEvents, canPush })) {
     core.info('No audit events and no API push configured, skipping summary')
     return
   }


### PR DESCRIPTION
Closes #69, closes #71. Picks up code-cargo/cargowall#98 and #92 by bumping the pinned binary to `v1.3.6-rc.2`.

## `api-failure-mode` (#69)

New input controlling posture when the policy can't be retrieved from the CodeCargo API: `audit` (default — downgrade, log don't block), `enforce` (use this step's config as-is), or `fail` (deny-all lockdown, step fails fast via the binary's failure sentinel).

- Only genuine retrieval failures (transport/5xx/malformed) act on it. 404 not-onboarded, rejected token, and inactive repo always fall back to the step's config — this is what makes the `audit` default safe for every repo without a CodeCargo account.
- An explicit, **valid** `mode:` wins over the default; an explicit `api-failure-mode` wins over both. Detecting an explicit `mode` required dropping its `action.yml` default (the runner materialises defaults into `INPUT_*` indistinguishably from user values); behaviourally inert since start.ts already applied `|| 'enforce'`.
- Lockdown is told apart from a generic startup crash via the structured downgrade record, so `fail-on-unsupported: false` keeps its warn-and-continue contract.

## `audit-summary` gates rendering only (#71)

`--audit-log` is always passed and `cargowall summary` always runs when the API is configured — that invocation *is* the SaaS push, and gating it made `audit-summary: false` jobs invisible to the dashboard. Removed the `postAuditResults()` no-op.

## Tests

107 unit tests (decision logic extracted to pure functions; key ones mutation-verified) + 4 e2e jobs against a local policy-API stub: 503→audit on both datapaths, 404→no change, fail→lockdown, and `audit-summary: false` still collects events. E2e is what catches a flag the pinned binary doesn't accept — kong exits on unknown flags.

Also hardens the pre-existing `api.github.com` allowed-connection checks against unauthenticated rate-limit 403s (flaky on shared runner IPs).