### PR TITLE
State-file staleness: mtime slack, post-step anchor, doc narrow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,9 @@ inputs:
       error, or an unusable policy. A repository that is not onboarded to
       CodeCargo, a rejected token, or an inactive repository always falls back
       to this step's configuration regardless of this setting.
-      Ignored when `offline: true` or `api-url` is empty.
+      When `offline: true` or `api-url` is empty the posture is never applied
+      (no fetch happens), but the value is still validated — a typo fails the
+      step immediately rather than surfacing as a silent posture choice later.
       Default: audit, except when `mode` is explicitly set (see README)
     required: false
   allowed-hosts:

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -25835,6 +25835,7 @@ var STARTUP_TIMEOUT = 30;
 var STEP_PLAN_FILE = "/tmp/cargowall-step-plan.json";
 var STEP_TIMESTAMPS_FILE = "/tmp/cargowall-step-timestamps.jsonl";
 var VALID_MODES = ["enforce", "audit"];
+var STALE_SLACK_MS = 2e3;
 async function showLastLog() {
   try {
     let logOutput = "";
@@ -26010,6 +26011,7 @@ async function start() {
   };
   const logFd = (0, import_fs7.openSync)(CARGOWALL_LOG, "w");
   const spawnedAtMs = Date.now();
+  saveState("cargowall-spawned-at", String(spawnedAtMs));
   const child2 = (0, import_child_process.spawn)("sudo", ["-E", "cargowall", ...args], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
@@ -26027,7 +26029,7 @@ async function start() {
   let ready = false;
   for (let i = 0; i < STARTUP_TIMEOUT; i++) {
     try {
-      if ((await import_fs6.promises.stat(READY_FILE)).mtimeMs >= spawnedAtMs) {
+      if ((await import_fs6.promises.stat(READY_FILE)).mtimeMs >= spawnedAtMs - STALE_SLACK_MS) {
         ready = true;
         break;
       }
@@ -26101,7 +26103,7 @@ async function sudoKillZero(pid) {
 }
 async function readPidFile(spawnedAtMs) {
   try {
-    if ((await import_fs6.promises.stat(PID_FILE)).mtimeMs < spawnedAtMs) {
+    if ((await import_fs6.promises.stat(PID_FILE)).mtimeMs < spawnedAtMs - STALE_SLACK_MS) {
       return null;
     }
     const out = await import_fs6.promises.readFile(PID_FILE, "utf8");
@@ -26133,7 +26135,7 @@ function sentinelReason(raw) {
 }
 async function readFailureFile(spawnedAtMs) {
   try {
-    if ((await import_fs6.promises.stat(FAILURE_FILE)).mtimeMs < spawnedAtMs) {
+    if ((await import_fs6.promises.stat(FAILURE_FILE)).mtimeMs < spawnedAtMs - STALE_SLACK_MS) {
       return null;
     }
   } catch {
@@ -26172,7 +26174,7 @@ async function readStateFile(filePath) {
 }
 async function readDowngradeFile(spawnedAtMs) {
   try {
-    if ((await import_fs6.promises.stat(DOWNGRADE_FILE)).mtimeMs < spawnedAtMs) {
+    if ((await import_fs6.promises.stat(DOWNGRADE_FILE)).mtimeMs < spawnedAtMs - STALE_SLACK_MS) {
       return null;
     }
   } catch {

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -153,18 +153,18 @@ var require_tunnel = __commonJS({
             res.statusCode
           );
           socket.destroy();
-          var error = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
           debug2("got illegal response body from proxy");
           socket.destroy();
-          var error = new Error("got illegal response body from proxy");
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("got illegal response body from proxy");
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self.removeSocket(placeholder);
           return;
         }
@@ -179,9 +179,9 @@ var require_tunnel = __commonJS({
           cause.message,
           cause.stack
         );
-        var error = new Error("tunneling socket could not be established, cause=" + cause.message);
-        error.code = "ECONNRESET";
-        options.request.emit("error", error);
+        var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
+        error2.code = "ECONNRESET";
+        options.request.emit("error", error2);
         self.removeSocket(placeholder);
       }
     };
@@ -1510,14 +1510,14 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
         const {
           connectParams: { version, protocol, port, host },
-          error
+          error: error2
         } = evt;
         debuglog(
           "connection to %s using %s%s errored - %s",
           `${host}${port ? `:${port}` : ""}`,
           protocol,
           version,
-          error.message
+          error2.message
         );
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
@@ -1548,14 +1548,14 @@ var require_diagnostics = __commonJS({
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
           request: { method, path: path6, origin },
-          error
+          error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
           path6,
-          error.message
+          error2.message
         );
       });
       isClientSet = true;
@@ -1590,7 +1590,7 @@ var require_diagnostics = __commonJS({
         diagnosticsChannel.channel("undici:client:connectError").subscribe((evt) => {
           const {
             connectParams: { version, protocol, port, host },
-            error
+            error: error2
           } = evt;
           debuglog(
             "connection to %s%s using %s%s errored - %s",
@@ -1598,7 +1598,7 @@ var require_diagnostics = __commonJS({
             port ? `:${port}` : "",
             protocol,
             version,
-            error.message
+            error2.message
           );
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
@@ -1868,16 +1868,16 @@ var require_request = __commonJS({
           this.onError(err);
         }
       }
-      onError(error) {
+      onError(error2) {
         this.onFinally();
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       onFinally() {
         if (this.errorHandler) {
@@ -5607,7 +5607,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
       }
       throwIfAborted(object[kState]);
       const promise = createDeferredPromise();
-      const errorSteps = (error) => promise.reject(error);
+      const errorSteps = (error2) => promise.reject(error2);
       const successSteps = (data) => {
         try {
           promise.resolve(convertBytesToJSValue(data));
@@ -7115,8 +7115,8 @@ var require_client_h2 = __commonJS({
         }
         request2.onRequestSent();
         client[kResume]();
-      } catch (error) {
-        abort(error);
+      } catch (error2) {
+        abort(error2);
       }
     }
     function writeStream(abort, socket, expectsPayload, h2stream, body, client, request2, contentLength) {
@@ -7271,8 +7271,8 @@ var require_redirect_handler = __commonJS({
       onUpgrade(statusCode, headers, socket) {
         this.handler.onUpgrade(statusCode, headers, socket);
       }
-      onError(error) {
-        this.handler.onError(error);
+      onError(error2) {
+        this.handler.onError(error2);
       }
       onHeaders(statusCode, headers, resume, statusText) {
         this.location = this.history.length >= this.maxRedirections || util.isDisturbed(this.opts.body) ? null : parseLocation(statusCode, headers);
@@ -8201,7 +8201,7 @@ var require_pool = __commonJS({
         this[kOptions] = { ...util.deepClone(options), connect, allowH2 };
         this[kOptions].interceptors = options.interceptors ? { ...options.interceptors } : void 0;
         this[kFactory] = factory;
-        this.on("connectionError", (origin2, targets, error) => {
+        this.on("connectionError", (origin2, targets, error2) => {
           for (const target of targets) {
             const idx = this[kClients].indexOf(target);
             if (idx !== -1) {
@@ -10568,13 +10568,13 @@ var require_mock_utils = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler2.onError(error);
+        handler2.onError(error2);
         return true;
       }
       if (typeof delay === "number" && delay > 0) {
@@ -10612,19 +10612,19 @@ var require_mock_utils = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler2);
-          } catch (error) {
-            if (error instanceof MockNotMatchedError) {
+          } catch (error2) {
+            if (error2 instanceof MockNotMatchedError) {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler2);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -10789,11 +10789,11 @@ var require_mock_interceptor = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -13311,17 +13311,17 @@ var require_fetch = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     function handleFetchDone(response) {
@@ -13417,12 +13417,12 @@ var require_fetch = __commonJS({
       );
     }
     var markResourceTiming = performance.markResourceTiming;
-    function abortFetch(p, request2, responseObject, error) {
+    function abortFetch(p, request2, responseObject, error2) {
       if (p) {
-        p.reject(error);
+        p.reject(error2);
       }
       if (request2.body != null && isReadable(request2.body?.stream)) {
-        request2.body.stream.cancel(error).catch((err) => {
+        request2.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -13434,7 +13434,7 @@ var require_fetch = __commonJS({
       }
       const response = responseObject[kState];
       if (response.body != null && isReadable(response.body?.stream)) {
-        response.body.stream.cancel(error).catch((err) => {
+        response.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -14255,13 +14255,13 @@ var require_fetch = __commonJS({
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onUpgrade(status, rawHeaders, socket) {
               if (status !== 101) {
@@ -14724,8 +14724,8 @@ var require_util4 = __commonJS({
                   }
                   fr[kResult] = result;
                   fireAProgressEvent("load", fr);
-                } catch (error) {
-                  fr[kError] = error;
+                } catch (error2) {
+                  fr[kError] = error2;
                   fireAProgressEvent("error", fr);
                 }
                 if (fr[kState] !== "loading") {
@@ -14734,13 +14734,13 @@ var require_util4 = __commonJS({
               });
               break;
             }
-          } catch (error) {
+          } catch (error2) {
             if (fr[kAborted]) {
               return;
             }
             queueMicrotask(() => {
               fr[kState] = "done";
-              fr[kError] = error;
+              fr[kError] = error2;
               fireAProgressEvent("error", fr);
               if (fr[kState] !== "loading") {
                 fireAProgressEvent("loadend", fr);
@@ -17012,11 +17012,11 @@ var require_connection = __commonJS({
         });
       }
     }
-    function onSocketError(error) {
+    function onSocketError(error2) {
       const { ws } = this;
       ws[kReadyState] = states.CLOSING;
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(error);
+        channels.socketError.publish(error2);
       }
       this.destroy();
     }
@@ -17298,9 +17298,9 @@ var require_receiver = __commonJS({
                 this.#extensions.get("permessage-deflate").decompress(
                   body,
                   this.#info.fin,
-                  (error, data) => {
-                    if (error) {
-                      failWebsocketConnection(this.ws, error.message);
+                  (error2, data) => {
+                    if (error2) {
+                      failWebsocketConnection(this.ws, error2.message);
                       return;
                     }
                     this.writeFragments(data);
@@ -18354,8 +18354,8 @@ var require_eventsource = __commonJS({
           pipeline(
             response.body.stream,
             eventSourceStream,
-            (error) => {
-              if (error?.aborted === false) {
+            (error2) => {
+              if (error2?.aborted === false) {
                 this.close();
                 this.dispatchEvent(new Event("error"));
               }
@@ -20386,12 +20386,12 @@ var OidcClient = class _OidcClient {
     return __awaiter3(this, void 0, void 0, function* () {
       var _a;
       const httpclient = _OidcClient.createHttpClient();
-      const res = yield httpclient.getJson(id_token_url).catch((error) => {
+      const res = yield httpclient.getJson(id_token_url).catch((error2) => {
         throw new Error(`Failed to get ID Token. 
  
-        Error Code : ${error.statusCode}
+        Error Code : ${error2.statusCode}
  
-        Error Message: ${error.message}`);
+        Error Message: ${error2.message}`);
       });
       const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
       if (!id_token) {
@@ -20412,8 +20412,8 @@ var OidcClient = class _OidcClient {
         const id_token = yield _OidcClient.getCall(id_token_url);
         setSecret(id_token);
         return id_token;
-      } catch (error) {
-        throw new Error(`Error message: ${error.message}`);
+      } catch (error2) {
+        throw new Error(`Error message: ${error2.message}`);
       }
     });
   }
@@ -21250,7 +21250,7 @@ var ToolRunner = class extends events.EventEmitter {
           this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
           state.CheckComplete();
         });
-        state.on("done", (error, exitCode) => {
+        state.on("done", (error2, exitCode) => {
           if (stdbuffer.length > 0) {
             this.emit("stdline", stdbuffer);
           }
@@ -21258,8 +21258,8 @@ var ToolRunner = class extends events.EventEmitter {
             this.emit("errline", errbuffer);
           }
           cp.removeAllListeners();
-          if (error) {
-            reject(error);
+          if (error2) {
+            reject(error2);
           } else {
             resolve2(exitCode);
           }
@@ -21352,14 +21352,14 @@ var ExecState = class _ExecState extends events.EventEmitter {
     this.emit("debug", message);
   }
   _setResult() {
-    let error;
+    let error2;
     if (this.processExited) {
       if (this.processError) {
-        error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+        error2 = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
       } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-        error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+        error2 = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
       } else if (this.processStderr && this.options.failOnStdErr) {
-        error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+        error2 = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
       }
     }
     if (this.timeout) {
@@ -21367,7 +21367,7 @@ var ExecState = class _ExecState extends events.EventEmitter {
       this.timeout = null;
     }
     this.done = true;
-    this.emit("done", error, this.processExitCode);
+    this.emit("done", error2, this.processExitCode);
   }
   static HandleTimeout(state) {
     if (state.done) {
@@ -21695,8 +21695,8 @@ function addHook(state, kind, name, hook2) {
   }
   if (kind === "error") {
     hook2 = (method, options) => {
-      return Promise.resolve().then(method.bind(null, options)).catch((error) => {
-        return orig(error, options);
+      return Promise.resolve().then(method.bind(null, options)).catch((error2) => {
+        return orig(error2, options);
       });
     };
   }
@@ -22256,26 +22256,26 @@ async function fetchWrapper(requestOptions) {
       // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
       ...requestOptions.body && { duplex: "half" }
     });
-  } catch (error) {
+  } catch (error2) {
     let message = "Unknown Error";
-    if (error instanceof Error) {
-      if (error.name === "AbortError") {
-        error.status = 500;
-        throw error;
+    if (error2 instanceof Error) {
+      if (error2.name === "AbortError") {
+        error2.status = 500;
+        throw error2;
       }
-      message = error.message;
-      if (error.name === "TypeError" && "cause" in error) {
-        if (error.cause instanceof Error) {
-          message = error.cause.message;
-        } else if (typeof error.cause === "string") {
-          message = error.cause;
+      message = error2.message;
+      if (error2.name === "TypeError" && "cause" in error2) {
+        if (error2.cause instanceof Error) {
+          message = error2.cause.message;
+        } else if (typeof error2.cause === "string") {
+          message = error2.cause;
         }
       }
     }
     const requestError = new RequestError(message, 500, {
       request: requestOptions
     });
-    requestError.cause = error;
+    requestError.cause = error2;
     throw requestError;
   }
   const status = fetchResponse.status;
@@ -25173,8 +25173,8 @@ function iterator(octokit, route, parameters) {
             }
           }
           return { value: normalizedResponse };
-        } catch (error) {
-          if (error.status !== 409) throw error;
+        } catch (error2) {
+          if (error2.status !== 409) throw error2;
           url = "";
           return {
             value: {
@@ -25260,9 +25260,6 @@ function getOctokit(token, options, ...additionalPlugins) {
   const GitHubWithPlugins = GitHub.plugin(...additionalPlugins);
   return new GitHubWithPlugins(getOctokitOptions(token, options));
 }
-
-// src/summary.ts
-var import_fs6 = require("fs");
 
 // src/diag.ts
 var import_fs5 = require("fs");
@@ -25374,7 +25371,11 @@ async function parseExecutedSteps(diagDir) {
   return names;
 }
 
+// src/start.ts
+var STALE_SLACK_MS = 2e3;
+
 // src/summary.ts
+var import_fs6 = require("fs");
 var AUDIT_LOG = "/tmp/cargowall-audit.json";
 var CARGOWALL_LOG2 = "/tmp/cargowall.log";
 var STEP_PLAN_FILE = "/tmp/cargowall-step-plan.json";
@@ -25450,8 +25451,8 @@ async function generateSummary(opts = { render: true }) {
             info(`GitHub API returned ${apiSteps.length} steps`);
           }
         }
-      } catch (error) {
-        info(`GitHub API step fetch failed: ${error}`);
+      } catch (error2) {
+        info(`GitHub API step fetch failed: ${error2}`);
       }
     }
     if (!apiCallMade && getState("watcher-pid")) {
@@ -25501,9 +25502,9 @@ async function generateSummary(opts = { render: true }) {
       try {
         const idToken = await getIDToken("codecargo");
         summaryArgs.push("--token", idToken);
-      } catch (error) {
+      } catch (error2) {
         info(
-          `No OIDC token available for the API push \u2014 skipping it. For CodeCargo platform integration the workflow needs "permissions: id-token: write". (${error})`
+          `No OIDC token available for the API push \u2014 skipping it. For CodeCargo platform integration the workflow needs "permissions: id-token: write". (${error2})`
         );
         for (const flag of ["--api-url", "--job-key", "--job-name", "--job-run-id", "--mode", "--default-action", "--job-status"]) {
           const idx = summaryArgs.findIndex((a) => a === flag);
@@ -25543,8 +25544,8 @@ async function generateSummary(opts = { render: true }) {
         }
       }
     }
-  } catch (error) {
-    warning(`Failed to generate audit summary: ${error}`);
+  } catch (error2) {
+    warning(`Failed to generate audit summary: ${error2}`);
   }
   if (render) {
     try {
@@ -25725,11 +25726,13 @@ async function run() {
       info("CargoWall was not started, skipping cleanup");
       return;
     }
+    const spawnedAtMs = Number(getState("cargowall-spawned-at"));
     let downgraded = false;
-    try {
-      await import_fs7.promises.access(DOWNGRADE_FILE);
-      downgraded = true;
-    } catch {
+    if (spawnedAtMs > 0) {
+      try {
+        downgraded = (await import_fs7.promises.stat(DOWNGRADE_FILE)).mtimeMs >= spawnedAtMs - STALE_SLACK_MS;
+      } catch {
+      }
     }
     if (!pid && !downgraded) {
       info("CargoWall never ran in this job, skipping summary");
@@ -25745,11 +25748,11 @@ async function run() {
     }
     await cleanup();
     info("CargoWall cleanup complete");
-  } catch (error) {
-    if (error instanceof Error) {
-      warning(`CargoWall cleanup error: ${error.message}`);
+  } catch (error2) {
+    if (error2 instanceof Error) {
+      warning(`CargoWall cleanup error: ${error2.message}`);
     } else {
-      warning(`CargoWall cleanup error: ${error}`);
+      warning(`CargoWall cleanup error: ${error2}`);
     }
   }
 }

--- a/src/post.test.ts
+++ b/src/post.test.ts
@@ -17,9 +17,10 @@ vi.mock('./summary', () => ({ generateSummary: vi.fn() }))
 vi.mock('fs', () => ({
   promises: {
     // No downgrade record by default — the common case.
-    access: vi.fn(async () => { throw new Error('ENOENT') }),
+    stat: vi.fn(async () => { throw new Error('ENOENT') }),
   },
 }))
+vi.mock('./start', () => ({ STALE_SLACK_MS: 2000 }))
 
 import * as core from '@actions/core'
 import { promises as fsp } from 'fs'
@@ -39,14 +40,17 @@ function withInputs(inputs: Record<string, string>): void {
   vi.mocked(core.getInput).mockImplementation((name: string) => inputs[name] ?? '')
 }
 
+/** State as start() leaves it on the happy path: pid saved, spawn anchor saved. */
+function withState(state: Record<string, string>): void {
+  vi.mocked(core.getState).mockImplementation((name: string) => state[name] ?? '')
+}
+
 describe('post', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // cargowall started, so the post step does its full job.
-    vi.mocked(core.getState).mockImplementation((name: string) =>
-      name === 'cargowall-pid' ? '4242' : ''
-    )
-    vi.mocked(fsp.access).mockRejectedValue(new Error('ENOENT'))
+    withState({ 'cargowall-pid': '4242', 'cargowall-spawned-at': String(Date.now() - 60_000) })
+    vi.mocked(fsp.stat).mockRejectedValue(new Error('ENOENT'))
     withInputs({})
   })
 
@@ -119,7 +123,7 @@ describe('post', () => {
     // start() threw pre-spawn (bad input, download failure): no pid state, no
     // downgrade record. A zero-event push would report effective mode
     // "enforce" for a job that had no filtering at all.
-    vi.mocked(core.getState).mockReturnValue('')
+    withState({})
     withInputs({ 'api-url': 'https://app.codecargo.com' })
 
     await runPost()
@@ -128,15 +132,43 @@ describe('post', () => {
     expect(cleanup).toHaveBeenCalled()
   })
 
-  it('still pushes for a policy lockdown (downgrade record, no pid)', async () => {
+  it('still pushes for a policy lockdown (fresh downgrade record, no pid)', async () => {
     // Lockdown never saves pid state (the throw happens before), but the
     // downgrade record exists and the push carries it to the dashboard.
-    vi.mocked(core.getState).mockReturnValue('')
-    vi.mocked(fsp.access).mockResolvedValue(undefined)
+    withState({ 'cargowall-spawned-at': String(Date.now() - 60_000) })
+    vi.mocked(fsp.stat).mockResolvedValue({ mtimeMs: Date.now() } as Awaited<ReturnType<typeof fsp.stat>>)
     withInputs({ 'api-url': 'https://app.codecargo.com' })
 
     await runPost()
 
     expect(generateSummary).toHaveBeenCalledWith({ render: true })
+  })
+
+  it('ignores a stale downgrade record from a previous job on a reused runner', async () => {
+    // The record predates this run's spawn anchor: a leftover, not this
+    // run's posture. Without the anchor this pushed a zero-event record for
+    // a job where cargowall never started.
+    withState({ 'cargowall-spawned-at': String(Date.now() - 60_000) })
+    vi.mocked(fsp.stat).mockResolvedValue(
+      { mtimeMs: Date.now() - 3_600_000 } as Awaited<ReturnType<typeof fsp.stat>>
+    )
+    withInputs({ 'api-url': 'https://app.codecargo.com' })
+
+    await runPost()
+
+    expect(generateSummary).not.toHaveBeenCalled()
+    expect(cleanup).toHaveBeenCalled()
+  })
+
+  it('ignores a downgrade record entirely when cargowall was never spawned', async () => {
+    // No spawn anchor ⇒ start() threw before spawning ⇒ any record on disk is
+    // definitionally from a previous job.
+    withState({})
+    vi.mocked(fsp.stat).mockResolvedValue({ mtimeMs: Date.now() } as Awaited<ReturnType<typeof fsp.stat>>)
+    withInputs({ 'api-url': 'https://app.codecargo.com' })
+
+    await runPost()
+
+    expect(generateSummary).not.toHaveBeenCalled()
   })
 })

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core'
 import { promises as fs } from 'fs'
 import { cleanup } from './cleanup'
+import { STALE_SLACK_MS } from './start'
 import { generateSummary } from './summary'
 
 // Shared with start.ts and the Go binary — see start.ts for the contract.
@@ -24,12 +25,20 @@ async function run(): Promise<void> {
     // input, failed download, spawn failure, crash, timeout — a zero-event
     // push would report effective mode "enforce" for a job that had no
     // filtering at all, and spend an Actions API request doing it.
+    //
+    // The downgrade record is anchored on the spawn time saved by start(),
+    // like every state-file reader there: clearStartupFiles' rm is
+    // best-effort, so a leftover record from a previous job on a reused
+    // runner must not count as this run's. Absent state means cargowall was
+    // never even spawned — any record is definitionally not this run's.
+    const spawnedAtMs = Number(core.getState('cargowall-spawned-at'))
     let downgraded = false
-    try {
-      await fs.access(DOWNGRADE_FILE)
-      downgraded = true
-    } catch {
-      // No downgrade record — the common case.
+    if (spawnedAtMs > 0) {
+      try {
+        downgraded = (await fs.stat(DOWNGRADE_FILE)).mtimeMs >= spawnedAtMs - STALE_SLACK_MS
+      } catch {
+        // No downgrade record — the common case.
+      }
     }
     if (!pid && !downgraded) {
       core.info('CargoWall never ran in this job, skipping summary')

--- a/src/start.spawn.test.ts
+++ b/src/start.spawn.test.ts
@@ -68,16 +68,17 @@ const DOWNGRADE_FILE = '/tmp/cargowall-downgrade'
  * probes them. fs.open returns a minimal FileHandle since the state-file
  * reader uses an O_NOFOLLOW open + bounded read rather than readFile. Present
  * files default to a future mtime (unambiguously fresher than the spawn
- * anchor); pass `staleMtimes` to model a leftover from a previous run.
+ * anchor); pass `mtimes` to model a leftover from a previous run (an old
+ * epoch) or a write landing just inside the staleness slack.
  */
-function withFiles(files: Record<string, string>, staleMtimes: string[] = []): void {
+function withFiles(files: Record<string, string>, mtimes: Record<string, number> = {}): void {
   vi.mocked(fsp.access).mockImplementation(async (p: unknown) => {
     if (String(p) in files || !String(p).startsWith('/tmp/cargowall')) return undefined
     throw new Error(`ENOENT: ${String(p)}`)
   })
   vi.mocked(fsp.stat).mockImplementation(async (p: unknown) => {
     if (!(String(p) in files)) throw new Error(`ENOENT: ${String(p)}`)
-    const mtimeMs = staleMtimes.includes(String(p)) ? 1 : Date.now() + 5000
+    const mtimeMs = mtimes[String(p)] ?? Date.now() + 5000
     return { mtimeMs, size: 1 } as Awaited<ReturnType<typeof fsp.stat>>
   })
   vi.mocked(fsp.lstat).mockImplementation(async (p: unknown) => {
@@ -383,7 +384,7 @@ describe('start() failure-sentinel handling', () => {
         [FAILURE_FILE]: sentinel('cargowall startup failed: crash from a previous run'),
         [READY_FILE]: '',
       },
-      [FAILURE_FILE],
+      { [FAILURE_FILE]: 1 },
     )
     let readyPolls = 0
     const statImpl = vi.mocked(fsp.stat).getMockImplementation()!
@@ -397,4 +398,18 @@ describe('start() failure-sentinel handling', () => {
     expect(result.supported).toBe(true)
     expect(core.error).not.toHaveBeenCalled()
   }, 10000)
+
+  it('treats a sentinel written moments before the spawn anchor as fresh (slack)', async () => {
+    withInputs({ 'fail-on-unsupported': 'true' })
+    // Coarse filesystem timestamps or write ordering can put a genuinely
+    // fresh sentinel's mtime a hair below spawnedAtMs. Within the slack it
+    // must still be trusted — otherwise a fast fatal error loses its precise
+    // reason to the generic 30s timeout.
+    withFiles(
+      { [FAILURE_FILE]: sentinel('cargowall startup failed: eBPF verifier rejected program') },
+      { [FAILURE_FILE]: Date.now() - 500 },
+    )
+
+    await expect(start()).rejects.toThrow(/eBPF verifier rejected program/)
+  })
 })

--- a/src/start.ts
+++ b/src/start.ts
@@ -25,6 +25,18 @@ const STEP_TIMESTAMPS_FILE = '/tmp/cargowall-step-timestamps.jsonl'
 
 const VALID_MODES = ['enforce', 'audit'] as const
 
+/**
+ * Slack for the state-file staleness anchor, mirroring wait-ready's
+ * staleSlack: a genuinely fresh file may carry an mtime a moment before the
+ * spawn anchor (write ordering, coarse filesystem timestamps — not something
+ * the action controls, especially on self-hosted runners). Without it, a
+ * fresh ready sentinel read as stale times out a healthy run, and a fast
+ * fatal error loses its precise reason to the generic timeout. Costs nothing
+ * on the staleness side — leftovers are from a previous job, minutes old,
+ * not two seconds. Exported so the post step applies the same tolerance.
+ */
+export const STALE_SLACK_MS = 2000
+
 async function showLastLog(): Promise<void> {
   try {
     let logOutput = ''
@@ -272,6 +284,11 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
   // failureSentinelAnchor, using the wall clock since writer and reader share
   // the machine.
   const spawnedAtMs = Date.now()
+  // Saved for the post step, whose downgrade-record check needs the same
+  // anchor: without it a leftover record from a previous job on a reused
+  // runner would trigger a push for a job where cargowall never started.
+  // Absence of this state tells the post step cargowall was never spawned.
+  core.saveState('cargowall-spawned-at', String(spawnedAtMs))
   const child = spawn('sudo', ['-E', 'cargowall', ...args], {
     detached: true,
     stdio: ['ignore', logFd, logFd],
@@ -307,7 +324,7 @@ export async function start(): Promise<{ supported: boolean; pid: number | null 
       // Anchored like the other state files: a stale ready file that survived
       // a failed clearStartupFiles rm must not short-circuit the wait with a
       // false "ready" while this run's cargowall is still coming up.
-      if ((await fs.stat(READY_FILE)).mtimeMs >= spawnedAtMs) {
+      if ((await fs.stat(READY_FILE)).mtimeMs >= spawnedAtMs - STALE_SLACK_MS) {
         ready = true
         break
       }
@@ -439,7 +456,7 @@ async function sudoKillZero(pid: number): Promise<boolean> {
  */
 async function readPidFile(spawnedAtMs: number): Promise<number | null> {
   try {
-    if ((await fs.stat(PID_FILE)).mtimeMs < spawnedAtMs) {
+    if ((await fs.stat(PID_FILE)).mtimeMs < spawnedAtMs - STALE_SLACK_MS) {
       return null
     }
     const out = await fs.readFile(PID_FILE, 'utf8')
@@ -504,7 +521,7 @@ export function sentinelReason(raw: string): string {
  */
 async function readFailureFile(spawnedAtMs: number): Promise<string | null> {
   try {
-    if ((await fs.stat(FAILURE_FILE)).mtimeMs < spawnedAtMs) {
+    if ((await fs.stat(FAILURE_FILE)).mtimeMs < spawnedAtMs - STALE_SLACK_MS) {
       return null
     }
   } catch {
@@ -570,7 +587,7 @@ export async function readStateFile(filePath: string): Promise<string | null> {
  */
 async function readDowngradeFile(spawnedAtMs: number): Promise<string | null> {
   try {
-    if ((await fs.stat(DOWNGRADE_FILE)).mtimeMs < spawnedAtMs) {
+    if ((await fs.stat(DOWNGRADE_FILE)).mtimeMs < spawnedAtMs - STALE_SLACK_MS) {
       return null
     }
   } catch {


### PR DESCRIPTION
Closes #74 — the three non-blocking notes from [PR 73's final review](https://github.com/code-cargo/cargowall-action/pull/73#pullrequestreview-4869378519), intended to land before the v1.3.6 tag since all three harden mechanisms that release introduces.

- **2s staleness slack** in all four spawn-anchor comparisons, mirroring `cmd/wait_ready.go`'s `staleSlack` and its rationale. Without it, a fresh ready sentinel read as stale times out a healthy run, and a fast fatal error loses its precise reason to the generic timeout.
- **Post-step anchor**: `start()` saves `cargowall-spawned-at` state; the post step's downgrade check now requires the record to postdate it (minus slack), and treats absent state — cargowall never spawned — as "any record is a previous job's". Closes the one unanchored `/tmp` reader.
- **`action.yml`**: `api-failure-mode` is no longer described as "ignored" when offline — the posture is never applied, but the value is still validated.

133 tests; the slack and both post-gate behaviours are mutation-verified (each reverted mutation fails exactly the tests written for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)