### PR TITLE
Setup download: bounded backoff, token escalation, pinned digests

### DIFF
--- a/.github/actions/assert-egress-allowed/action.yml
+++ b/.github/actions/assert-egress-allowed/action.yml
@@ -1,0 +1,36 @@
+name: Assert egress allowed
+description: >-
+  Assert that the firewall allows egress to a URL. Any HTTP response counts,
+  including 4xx/5xx — github.com's edge intermittently sheds load to
+  hosted-runner IPs (#79), and these probes test cargowall's verdict, not the
+  remote's HTTP health. A genuine block yields no response at all (refused DNS
+  or a connect timeout) and still fails. The retry loop lives in the shell, not
+  in curl: the edge has also served bodies mangled enough for a write error
+  (exit 23), which curl aborts on without retrying even under
+  --retry-all-errors.
+inputs:
+  url:
+    description: URL to probe
+    required: true
+  attempts:
+    description: Maximum probe attempts
+    required: false
+    default: '5'
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        URL: ${{ inputs.url }}
+        ATTEMPTS: ${{ inputs.attempts }}
+      run: |
+        for i in $(seq 1 "$ATTEMPTS"); do
+          if curl -s --connect-timeout 5 --max-time 30 -o /dev/null "$URL"; then
+            echo "HTTP response received from $URL (attempt $i) — egress allowed"
+            exit 0
+          fi
+          echo "attempt $i: no HTTP response from $URL, retrying in 3 s"
+          sleep 3
+        done
+        echo "ERROR: no HTTP response from $URL after $ATTEMPTS attempts — egress appears blocked"
+        exit 1

--- a/.github/workflows/check-digests.yml
+++ b/.github/workflows/check-digests.yml
@@ -1,0 +1,64 @@
+name: Check digests
+
+# CARGOWALL_DIGESTS in src/setup.ts is the runtime trust anchor: setup verifies
+# the downloaded binary against the pin and nothing else. That is sound because
+# the Sigstore attestation's subject IS the binary's SHA-256 — byte-equality
+# with the pin proves the same artifact the attestation signs — but it makes
+# this workflow the place provenance is actually verified. So it downloads the
+# real binaries, checks each against the pin, and runs `gh attestation verify`
+# on each; the weekly run re-attests the published assets between releases.
+# A stale or unattested pin fails here, not in a consumer's job.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * 1' # weekly re-attestation of the pinned release
+
+jobs:
+  check-digests:
+    name: Pinned digests match attested release binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify pinned digests and provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          version=$(grep -oP "CARGOWALL_VERSION = '\K[^']+" src/setup.ts)
+          echo "Pinned version: $version"
+
+          status=0
+          for arch in amd64 arm64; do
+            asset="cargowall-linux-$arch"
+            pinned=$(grep -oP "^  $arch: '\K[0-9a-f]{64}" src/setup.ts)
+
+            gh release download "$version" \
+              --repo code-cargo/cargowall \
+              --pattern "$asset" \
+              --output "$asset"
+
+            actual=$(sha256sum "$asset" | awk '{print $1}')
+            if [ "$pinned" != "$actual" ]; then
+              echo "::error::Digest drift for $arch — pinned $pinned, published binary is $actual"
+              status=1
+              continue
+            fi
+
+            if ! gh attestation verify "$asset" --repo code-cargo/cargowall; then
+              echo "::error::Provenance verification failed for $asset $version"
+              status=1
+              continue
+            fi
+
+            echo "$arch OK ($pinned, provenance verified)"
+          done
+
+          exit $status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,17 +42,14 @@ jobs:
           fi
 
       - name: Test allowed connection (github.com)
-        run: |
-          curl -sf --max-time 10 https://github.com > /dev/null
-          echo "Successfully connected to github.com"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://github.com
 
       - name: Test allowed connection (api.github.com)
-        run: |
-          # -f omitted on purpose: unauthenticated api.github.com often 403s (per-IP
-          # rate limit shared across hosted runners). Any HTTP response proves the
-          # firewall allowed the connection, which is what this step tests.
-          curl -s --max-time 10 -o /dev/null https://api.github.com
-          echo "Successfully connected to api.github.com"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://api.github.com
 
       - name: Test blocked connection (example.com)
         run: |
@@ -89,17 +86,14 @@ jobs:
             api.github.com
 
       - name: Test allowed connection (github.com)
-        run: |
-          curl -sf --max-time 10 https://github.com > /dev/null
-          echo "Successfully connected to github.com"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://github.com
 
       - name: Test allowed connection (api.github.com)
-        run: |
-          # -f omitted on purpose: unauthenticated api.github.com often 403s (per-IP
-          # rate limit shared across hosted runners). Any HTTP response proves the
-          # firewall allowed the connection, which is what this step tests.
-          curl -s --max-time 10 -o /dev/null https://api.github.com
-          echo "Successfully connected to api.github.com"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://api.github.com
 
       - name: Test blocked connection (example.com)
         run: |
@@ -176,11 +170,10 @@ jobs:
           allowed-hosts: |
             app.codecargo.com
 
-      - name: Test connection to allowed CIDR
-        run: |
-          # github.com IPs are in the allowed CIDR
-          curl -sf --max-time 10 https://github.com > /dev/null
-          echo "Successfully connected via allowed CIDR"
+      - name: Test connection to allowed CIDR (github.com IPs)
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://github.com
 
   test-graceful-degradation:
     name: Graceful Degradation
@@ -260,14 +253,14 @@ jobs:
             *.ubuntu.com
 
       - name: Test allowed connection (archive.ubuntu.com matches *.ubuntu.com)
-        run: |
-          curl -sf --max-time 10 https://archive.ubuntu.com > /dev/null
-          echo "Successfully connected to archive.ubuntu.com via *.ubuntu.com wildcard"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://archive.ubuntu.com
 
       - name: Test allowed connection (security.ubuntu.com matches *.ubuntu.com)
-        run: |
-          curl -sf --max-time 10 https://security.ubuntu.com > /dev/null
-          echo "Successfully connected to security.ubuntu.com via *.ubuntu.com wildcard"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://security.ubuntu.com
 
       - name: Test bare domain not matched (ubuntu.com should not match *.ubuntu.com)
         run: |
@@ -571,9 +564,9 @@ jobs:
           ps -o comm= -p "$PID" | tr -d '[:space:]' | grep -qx cargowall
 
       - name: Test allowed connection (github.com)
-        run: |
-          curl -sf --max-time 10 https://github.com > /dev/null
-          echo "Successfully connected to github.com"
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://github.com
 
       - name: Test blocked connection (example.com)
         run: |
@@ -680,14 +673,18 @@ jobs:
           # way — see the audit-summary:false assertion below.
           test -f /tmp/cargowall-audit.json
 
-      - name: Verify audit posture reaches BOTH datapaths
+      - name: Verify audit posture reaches the DNS datapath
         run: |
-          # example.com is not in allowed-hosts. In audit mode the eBPF layer
-          # must not block it AND the DNS proxy must not refuse it — the split
-          # that made audit-summary:false look like enforcement.
+          # example.com is not in allowed-hosts. In audit mode the DNS proxy
+          # must not refuse it — half of the split that made
+          # audit-summary:false look like enforcement.
           getent hosts example.com
-          curl -sf --max-time 10 https://example.com > /dev/null
-          echo "example.com reachable, as audit mode requires"
+
+      - name: Verify audit posture reaches the eBPF datapath
+        # The other half: the eBPF layer must not block the connection either.
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://example.com
 
   test-api-failure-not-onboarded:
     name: API 404 does not change posture
@@ -717,7 +714,7 @@ jobs:
             github.com
             api.github.com
 
-      - name: Assert enforcement is intact
+      - name: Assert no downgrade was recorded
         run: |
           test '${{ steps.cargowall.outputs.supported }}' = 'true'
 
@@ -727,9 +724,13 @@ jobs:
             exit 1
           fi
 
-          curl -sf --max-time 10 https://github.com > /dev/null
-          echo "github.com still allowed"
+      - name: Assert github.com is still allowed
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://github.com
 
+      - name: Assert example.com is still blocked
+        run: |
           if curl -sf --max-time 5 https://example.com > /dev/null 2>&1; then
             echo "ERROR: example.com should still be blocked — posture was downgraded on an authoritative 404"
             exit 1
@@ -815,7 +816,9 @@ jobs:
             api.github.com
 
       - name: Generate some traffic
-        run: curl -sf --max-time 10 https://github.com > /dev/null
+        uses: ./.github/actions/assert-egress-allowed
+        with:
+          url: https://github.com
 
       - name: Assert events are still collected
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,23 @@ npm run build
 
 The `dist/` directory must be committed — GitHub Actions runs the compiled output directly.
 
+### Bumping the cargowall version
+
+`CARGOWALL_VERSION` in `src/setup.ts` is pinned alongside `CARGOWALL_DIGESTS`,
+the SHA-256 of each published binary. Both must move together — the pinned
+digest is the *only* verification setup performs at runtime, so it carries the
+provenance story too (the Sigstore attestation's subject is this digest).
+
+```sh
+curl -sSL https://github.com/code-cargo/cargowall/releases/download/vX.Y.Z/checksums.txt
+```
+
+`.github/workflows/check-digests.yml` downloads the published binaries,
+compares them to the pins, and runs `gh attestation verify` on each — on every
+push/PR and weekly. A forgotten update, a digest without provenance, or a
+tampered release asset is caught in this repo's CI rather than in a consumer's
+job.
+
 ### Project Structure
 
 - `src/main.ts` — Action entry point

--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ For complex configurations, use a JSON or YAML config file:
 | `sudo-allow-commands`        | Command paths to allow via sudo when locked, one per line                                                                                                                                                                                                                              |                                                |
 | `dns-upstream`               | Upstream DNS server (auto-detected if not set)                                                                                                                                                                                                                                         | auto-detect                                    |
 | `allow-existing-connections` | Allow pre-existing TCP connections at startup                                                                                                                                                                                                                                          | `true`                                         |
-| `binary-path`                | Path to a pre-built cargowall binary (skips download)                                                                                                                                                                                                                                  |                                                |
+| `binary-path`                | Path to a pre-built cargowall binary. Skips the download, and with it the pinned-digest verification — see [Setup fails downloading the binary](#setup-fails-downloading-the-binary)                                                                                                    |                                                |
 | `debug`                      | Enable debug logging                                                                                                                                                                                                                                                                   | `false`                                        |
 | `audit-summary`              | Render the audit summary into the workflow run summary. **Rendering only** — event collection and the CodeCargo API push happen either way; use `offline: true` to stop API communication                                                                                               | `true`                                         |
 | `skip-actions-api`           | Skip the GitHub Actions API call that enriches audit-summary step names/status (falls back to local `_diag` data); set `true` when near the per-repo rate limit                                                                                                                        | `false`                                        |
-| `github-token`               | GitHub token for fetching step timing in the audit summary                                                                                                                                                                                                                             | `${{ github.token }}`                          |
+| `github-token`               | GitHub token for fetching step timing in the audit summary, and for retrying the binary download authenticated when the anonymous request is throttled                                                                                                                                 | `${{ github.token }}`                          |
 | `api-url`                    | CodeCargo API URL for audit upload and policy fetch (policy requires GitHub App)                                                                                                                                                                                                       | `https://app.codecargo.com`                    |
 | `api-failure-mode`           | Posture when the policy can't be retrieved from the CodeCargo API: `audit`, `enforce`, or `fail`. Only genuine retrieval failures act on it — but an *unreachable* API counts, so the `audit` default affects non-platform repos too. See [When the CodeCargo Policy Can't Be Fetched](#when-the-codecargo-policy-cant-be-fetched)                                               | `audit` (`enforce` if `mode` is set)           |
 | `offline`                    | Skip all CodeCargo API communication (audit upload and policy fetch)                                                                                                                                                                                                                   | `false`                                        |
@@ -387,6 +387,22 @@ With this configuration, `sudo apt-get install ...` and `sudo docker build ...` 
 
 Sudo lockdown also removes the current user from the `docker` group. This is because Docker group membership grants the ability to run containers with root-level access, which could be used to bypass the firewall.
 
+### Binary Verification
+
+The cargowall binary is pinned to a version *and* a SHA-256 digest baked into
+each release of this action, so pinning the action by tag or SHA pins the
+binary too. At runtime, setup downloads the binary and checks it against the
+pinned digest — nothing served alongside the binary is trusted, and a
+substituted asset fails the check regardless of what the download host claims.
+
+Build provenance is verified where the pin is made, not in every job: the
+Sigstore attestation's subject *is* the binary's SHA-256, so a byte-for-byte
+match with the pin proves the same artifact the attestation signs. The
+`check-digests` CI workflow downloads the published binaries, verifies each
+against the pin, and runs `gh attestation verify` on each — on every change
+and on a weekly schedule — so an unattested or tampered release asset fails in
+this repository's CI, never in your job.
+
 ## Runner Compatibility
 
 | Runner Type                   | eBPF Support | Notes                            |
@@ -421,6 +437,67 @@ If DNS queries are timing out:
 1. Ensure Docker is running before the action
 2. CargoWall automatically configures Docker DNS
 3. Check `/etc/docker/daemon.json` was updated
+
+### Setup fails downloading the binary
+
+A failure in the `CargoWall Setup` group — `socket hang up`, `HTTP 503`, or
+`Failed to download https://github.com/...` — happens **before the firewall
+starts**, so nothing was blocked. The message is a plain network failure
+fetching the release asset from GitHub's CDN, not a policy decision. (The
+"CargoWall firewall is active" annotation on the same run comes from other
+jobs; annotations are aggregated per run.)
+
+The action downloads a single asset — the binary — with five attempts and
+backoff, and logs every retry —
+so a blip that recovered is visible in the log rather than silent. If asset
+delivery is degraded for longer than that, vendor the binary and skip the
+download entirely with `binary-path`:
+
+```yaml
+- name: Fetch cargowall
+  run: |
+    gh release download v1.3.6 \
+      --repo code-cargo/cargowall \
+      --pattern "cargowall-linux-${ARCH}" \
+      --output "$RUNNER_TEMP/cargowall"
+    gh attestation verify "$RUNNER_TEMP/cargowall" --repo code-cargo/cargowall
+  env:
+    GH_TOKEN: ${{ github.token }}
+    ARCH: ${{ runner.arch == 'ARM64' && 'arm64' || 'amd64' }}
+
+- uses: code-cargo/cargowall-action@v1
+  with:
+    binary-path: ${{ runner.temp }}/cargowall
+```
+
+Pair it with `actions/cache` to make the download a cold-start-only cost:
+
+```yaml
+- id: cache
+  uses: actions/cache@v4
+  with:
+    path: ${{ runner.temp }}/cargowall
+    key: cargowall-v1.3.6-${{ runner.arch }}
+
+- if: steps.cache.outputs.cache-hit != 'true'
+  run: gh release download v1.3.6 --repo code-cargo/cargowall --pattern "cargowall-linux-${ARCH}" --output "$RUNNER_TEMP/cargowall"
+  env:
+    GH_TOKEN: ${{ github.token }}
+    ARCH: ${{ runner.arch == 'ARM64' && 'arm64' || 'amd64' }}
+
+# Unconditional: a cache entry is writable by any workflow in the repository,
+# so the restored binary needs verifying just as much as a fresh download.
+- run: gh attestation verify "$RUNNER_TEMP/cargowall" --repo code-cargo/cargowall
+  env:
+    GH_TOKEN: ${{ github.token }}
+
+- uses: code-cargo/cargowall-action@v1
+  with:
+    binary-path: ${{ runner.temp }}/cargowall
+```
+
+`binary-path` skips the action's own pinned-digest verification — the binary is
+used as given — so verify it yourself as above.
 
 ## CodeCargo Platform
 

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ inputs:
     description: 'Allow pre-existing TCP connections at startup (prevents blocking connections established before cargowall)'
     default: 'true'
   binary-path:
-    description: 'Path to a pre-built cargowall binary (skips download, useful for CI testing)'
+    description: 'Path to a pre-built cargowall binary. Skips the download and the action''s checksum/provenance verification — the binary is used as given, so verify it in the step that fetches it'
     required: false
   debug:
     description: 'Enable debug logging'
@@ -90,7 +90,7 @@ inputs:
     description: 'Skip the GitHub Actions API call used to enrich audit-summary step names and job status. Falls back to local _diag data. Set to true on installations near the per-repo rate limit (1,000 req/hr).'
     default: 'false'
   github-token:
-    description: 'GitHub token for fetching step timing in audit summary'
+    description: 'GitHub token for fetching step timing in audit summary, and for retrying the binary download authenticated when the anonymous request is throttled (403/503)'
     default: ${{ github.token }}
   api-url:
     description: 'CodeCargo API URL for audit upload and policy fetch (policy requires CodeCargo GitHub App installation). Requires permissions: id-token: write'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -21553,6 +21553,7 @@ function getIDToken(aud) {
 }
 
 // src/setup.ts
+var import_crypto = require("crypto");
 var import_fs2 = require("fs");
 var os6 = __toESM(require("os"));
 var path4 = __toESM(require("path"));
@@ -21561,38 +21562,89 @@ var import_promises2 = require("timers/promises");
 var INSTALL_DIR = "/usr/local/bin";
 var BINARY_NAME = "cargowall";
 var CARGOWALL_VERSION = "v1.3.6";
+var CARGOWALL_DIGESTS = {
+  amd64: "ac511897cb7952bc61c0a8b99d9bf73fd95148dd8062562aa3862d6c72e53865",
+  arm64: "08b56f7d25c3bd5f6c65f3bd4932bc587f049c6eb1c1a0bfc7343e8875c158f7"
+};
+function linuxArch() {
+  const archRaw = os6.arch();
+  switch (archRaw) {
+    case "x64":
+      return "amd64";
+    case "arm64":
+      return "arm64";
+    default:
+      throw new Error(`Unsupported architecture: ${archRaw}`);
+  }
+}
 var http2 = new HttpClient("cargowall-action");
-async function downloadAsset(url, dest) {
+var DOWNLOAD_RETRY_DELAYS_MS = [500, 2e3, 5e3, 1e4];
+function withJitter(baseMs) {
+  return Math.round(baseMs / 2 + Math.random() * baseMs);
+}
+function isRetryableStatus(status) {
+  return status >= 500 || status === 408 || status === 429;
+}
+function isThrottleStatus(status) {
+  return status === 403 || status === 503;
+}
+async function downloadAsset(url, dest, token = "") {
+  const asset = url.split("/").pop() || url;
+  let authenticated = false;
   const attempt = async () => {
-    const res = await http2.get(url);
-    const status2 = res.message.statusCode ?? 0;
-    if (status2 < 200 || status2 >= 300) {
-      res.message.resume();
-      return status2;
+    try {
+      const headers = authenticated ? { authorization: `Bearer ${token}` } : void 0;
+      const res = await http2.get(url, headers);
+      const status = res.message.statusCode ?? 0;
+      if (status < 200 || status >= 300) {
+        res.message.resume();
+        return {
+          ok: false,
+          reason: `HTTP ${status}`,
+          status,
+          retryable: isRetryableStatus(status)
+        };
+      }
+      await (0, import_promises.pipeline)(res.message, (0, import_fs2.createWriteStream)(dest));
+      return { ok: true };
+    } catch (error2) {
+      return {
+        ok: false,
+        reason: error2 instanceof Error ? error2.message : String(error2),
+        status: 0,
+        retryable: true
+      };
     }
-    await (0, import_promises.pipeline)(res.message, (0, import_fs2.createWriteStream)(dest));
-    return status2;
   };
-  let status;
-  try {
-    status = await attempt();
-  } catch {
+  for (let i = 0; ; i++) {
+    const result = await attempt();
+    if (result.ok) {
+      if (i > 0) info(`Downloaded ${asset} on attempt ${i + 1}`);
+      return;
+    }
     await import_fs2.promises.unlink(dest).catch(() => {
     });
-    await (0, import_promises2.setTimeout)(500);
-    return attempt();
+    const escalate = token !== "" && !authenticated && (isThrottleStatus(result.status) || result.retryable && i >= 1);
+    if (escalate) {
+      authenticated = true;
+      info(`Download of ${asset} hit ${result.reason} \u2014 retrying authenticated`);
+    } else if (!result.retryable) {
+      throw new Error(`Failed to download ${url}: ${result.reason}`);
+    }
+    if (i >= DOWNLOAD_RETRY_DELAYS_MS.length) {
+      throw new Error(`Failed to download ${url} after ${i + 1} attempts: ${result.reason}`);
+    }
+    const delay = withJitter(DOWNLOAD_RETRY_DELAYS_MS[i]);
+    info(
+      `Download of ${asset} failed (${result.reason}); retrying in ${delay} ms \u2014 attempt ${i + 2} of ${DOWNLOAD_RETRY_DELAYS_MS.length + 1}`
+    );
+    await (0, import_promises2.setTimeout)(delay);
   }
-  if (status >= 500) {
-    await import_fs2.promises.unlink(dest).catch(() => {
-    });
-    await (0, import_promises2.setTimeout)(500);
-    return attempt();
-  }
-  if (status < 200 || status >= 300) {
-    await import_fs2.promises.unlink(dest).catch(() => {
-    });
-  }
-  return status;
+}
+async function sha256File(file) {
+  const hash = (0, import_crypto.createHash)("sha256");
+  await (0, import_promises.pipeline)((0, import_fs2.createReadStream)(file), hash);
+  return hash.digest("hex");
 }
 async function setup() {
   const failOnUnsupported = getInput("fail-on-unsupported") === "true";
@@ -21631,24 +21683,11 @@ async function installFromLocalPath(binaryPath) {
   } catch {
     throw new Error(`Binary not found at ${binaryPath}`);
   }
-  await exec("chmod", ["+x", binaryPath]);
-  await exec("sudo", ["cp", binaryPath, path4.join(INSTALL_DIR, BINARY_NAME)]);
-  info("Installed cargowall from local path");
+  await installBinary(binaryPath);
   await verifyInstallation();
 }
 async function downloadAndInstall() {
-  const archRaw = os6.arch();
-  let arch3;
-  switch (archRaw) {
-    case "x64":
-      arch3 = "amd64";
-      break;
-    case "arm64":
-      arch3 = "arm64";
-      break;
-    default:
-      throw new Error(`Unsupported architecture: ${archRaw}`);
-  }
+  const arch3 = linuxArch();
   info(`Detected architecture: ${arch3}`);
   const platform3 = os6.platform();
   if (platform3 !== "linux") {
@@ -21661,66 +21700,28 @@ async function downloadAndInstall() {
   info(`Downloading ${binaryAsset} from ${repo} release ${CARGOWALL_VERSION}`);
   const tempDir = await import_fs2.promises.mkdtemp(path4.join(os6.tmpdir(), "cargowall-"));
   const binaryDest = path4.join(tempDir, BINARY_NAME);
+  const token = getInput("github-token");
   try {
-    const binStatus = await downloadAsset(`${releaseBase}/${binaryAsset}`, binaryDest);
-    if (binStatus < 200 || binStatus >= 300) {
-      throw new Error(`Failed to download cargowall binary (HTTP ${binStatus})`);
-    }
-    const checksumDest = path4.join(tempDir, "checksums.txt");
-    const csStatus = await downloadAsset(`${releaseBase}/checksums.txt`, checksumDest);
-    if (csStatus < 200 || csStatus >= 300) {
-      throw new Error(`Failed to download checksums.txt (HTTP ${csStatus})`);
-    }
-    info("Verifying checksum...");
-    const checksums = await import_fs2.promises.readFile(checksumDest, "utf8");
-    const expectedLine = checksums.split("\n").find((l) => l.includes(binaryAsset));
-    if (!expectedLine) {
-      throw new Error(`No checksum entry for ${binaryAsset} in checksums.txt`);
-    }
-    const expectedChecksum = expectedLine.trim().split(/\s+/)[0];
-    let actualChecksum = "";
-    await exec("sha256sum", [binaryDest], {
-      listeners: {
-        stdout: (data) => {
-          actualChecksum += data.toString();
-        }
-      }
-    });
-    actualChecksum = actualChecksum.trim().split(/\s+/)[0];
-    if (expectedChecksum !== actualChecksum) {
+    await downloadAsset(`${releaseBase}/${binaryAsset}`, binaryDest, token);
+    info("Verifying checksum against pinned digest...");
+    const actualDigest = await sha256File(binaryDest);
+    if (actualDigest !== CARGOWALL_DIGESTS[arch3]) {
       throw new Error(`Checksum verification failed
-Expected: ${expectedChecksum}
-Actual: ${actualChecksum}`);
+Expected: ${CARGOWALL_DIGESTS[arch3]}
+Actual: ${actualDigest}`);
     }
     info("Checksum verified");
-    const bundleDest = path4.join(tempDir, "attestations.sigstore.json");
-    const bundleStatus = await downloadAsset(`${releaseBase}/attestations.sigstore.json`, bundleDest);
-    if (bundleStatus < 200 || bundleStatus >= 300) {
-      throw new Error(`Failed to download attestations.sigstore.json (HTTP ${bundleStatus})`);
-    }
-    info("Verifying provenance...");
-    try {
-      await which("gh", true);
-    } catch {
-      throw new Error("gh CLI not found on this runner \u2014 required for provenance verification");
-    }
-    const verifyResult = await exec(
-      "gh",
-      ["attestation", "verify", binaryDest, "--bundle", bundleDest, "--repo", repo],
-      { ignoreReturnCode: true }
-    );
-    if (verifyResult !== 0) {
-      throw new Error("Provenance verification failed \u2014 binary attestation could not be confirmed");
-    }
-    info("Provenance verified");
-    await exec("chmod", ["+x", binaryDest]);
-    await exec("sudo", ["mv", binaryDest, path4.join(INSTALL_DIR, BINARY_NAME)]);
-    info(`Installed cargowall to ${INSTALL_DIR}/${BINARY_NAME}`);
+    await installBinary(binaryDest);
   } finally {
     await import_fs2.promises.rm(tempDir, { recursive: true, force: true }).catch(() => {
     });
   }
   await verifyInstallation();
+}
+async function installBinary(from) {
+  await exec("chmod", ["+x", from]);
+  await exec("sudo", ["cp", from, path4.join(INSTALL_DIR, BINARY_NAME)]);
+  info(`Installed cargowall to ${INSTALL_DIR}/${BINARY_NAME}`);
 }
 async function verifyInstallation() {
   try {

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
+import { Readable } from 'stream'
+import { promises as fs } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+/**
+ * #79: setup ran before the firewall is up, so a single ECONNRESET from the
+ * release CDN failed the whole job — the old one-shot retry gave the CDN
+ * ~650 ms to recover. These tests pin the backoff loop's shape: what gets
+ * retried, what doesn't, and that nothing partial survives a failed attempt.
+ *
+ * Real filesystem, mocked socket: the truncation cases are exactly the ones an
+ * fs mock papers over.
+ */
+
+// Hoisted: setup.ts constructs its HttpClient at module scope, so the mock
+// factory runs before a plain `const` here would be initialized.
+const { get } = vi.hoisted(() => ({ get: vi.fn() }))
+
+vi.mock('@actions/http-client', () => ({
+  HttpClient: class {
+    get = get
+  }
+}))
+vi.mock('@actions/core', () => ({
+  info: vi.fn(),
+  warning: vi.fn(),
+  getInput: vi.fn(() => ''),
+  startGroup: vi.fn(),
+  endGroup: vi.fn()
+}))
+// Sleep for real would make the exhaustion test a 17.5 s test.
+vi.mock('timers/promises', () => ({ setTimeout: vi.fn(async () => undefined) }))
+
+import * as core from '@actions/core'
+import { setTimeout as sleep } from 'timers/promises'
+import { downloadAsset, sha256File } from './setup'
+
+const URL = 'https://github.com/code-cargo/cargowall/releases/download/v1.3.6/cargowall-linux-amd64'
+
+/** A 2xx whose body streams cleanly. */
+function respondOk(body = 'binary-bytes'): unknown {
+  const message = Readable.from([body]) as Readable & { statusCode: number }
+  message.statusCode = 200
+  return { message }
+}
+
+/** A non-2xx. The body is drained, not written. */
+function respondStatus(statusCode: number): unknown {
+  const message = Readable.from(['<html>error</html>']) as Readable & { statusCode: number }
+  message.statusCode = statusCode
+  return { message }
+}
+
+/** A 2xx that dies partway through the body — the truncated-download case. */
+function respondTruncated(): unknown {
+  const message = new Readable({
+    read() {
+      this.push('half-a-')
+      this.destroy(new Error('aborted'))
+    }
+  }) as Readable & { statusCode: number }
+  message.statusCode = 200
+  return { message }
+}
+
+const delays = (): number[] => vi.mocked(sleep).mock.calls.map(c => c[0] as number)
+const retryLogs = (): string[] =>
+  vi.mocked(core.info).mock.calls.map(c => String(c[0])).filter(m => m.includes('retrying in'))
+
+let dir: string
+let dest: string
+
+beforeAll(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cw-download-'))
+})
+
+afterAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('downloadAsset', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    dest = path.join(dir, `asset-${vi.mocked(get).mock.calls.length}-${process.hrtime.bigint()}`)
+  })
+
+  it('writes the body on a clean first attempt', async () => {
+    get.mockResolvedValueOnce(respondOk())
+    await downloadAsset(URL, dest)
+    expect(await fs.readFile(dest, 'utf8')).toBe('binary-bytes')
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('survives a socket reset and logs the retry', async () => {
+    get.mockRejectedValueOnce(new Error('socket hang up'))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest)
+
+    expect(await fs.readFile(dest, 'utf8')).toBe('binary-bytes')
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(retryLogs()).toEqual([
+      expect.stringContaining('cargowall-linux-amd64 failed (socket hang up)')
+    ])
+    expect(retryLogs()[0]).toContain('attempt 2 of 5')
+  })
+
+  it('retries a 5xx', async () => {
+    get.mockResolvedValueOnce(respondStatus(503))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest)
+
+    expect(await fs.readFile(dest, 'utf8')).toBe('binary-bytes')
+    expect(retryLogs()[0]).toContain('(HTTP 503)')
+  })
+
+  it('retries a 429 and a 408, which the old 5xx-only path let through', async () => {
+    get.mockResolvedValueOnce(respondStatus(429))
+    get.mockResolvedValueOnce(respondStatus(408))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest)
+
+    expect(get).toHaveBeenCalledTimes(3)
+  })
+
+  it('discards a truncated body instead of leaving it for the checksum step', async () => {
+    get.mockResolvedValueOnce(respondTruncated())
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest)
+
+    expect(await fs.readFile(dest, 'utf8')).toBe('binary-bytes')
+  })
+
+  it('never sends a token on the first attempt', async () => {
+    get.mockResolvedValueOnce(respondOk())
+    await downloadAsset(URL, dest, 'ghs-token')
+    expect(get.mock.calls[0][1]).toBeUndefined()
+  })
+
+  it('escalates to an authenticated retry after a 503', async () => {
+    get.mockResolvedValueOnce(respondStatus(503))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest, 'ghs-token')
+
+    expect(get.mock.calls[1][1]).toEqual({ authorization: 'Bearer ghs-token' })
+    expect(vi.mocked(core.info).mock.calls.map(c => String(c[0]))).toContainEqual(
+      expect.stringContaining('hit HTTP 503 — retrying authenticated')
+    )
+  })
+
+  it('escalates on a 403, which is otherwise fatal', async () => {
+    get.mockResolvedValueOnce(respondStatus(403))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest, 'ghs-token')
+
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(get.mock.calls[1][1]).toEqual({ authorization: 'Bearer ghs-token' })
+  })
+
+  it('fails fast on a 403 when there is no token to escalate with', async () => {
+    get.mockResolvedValueOnce(respondStatus(403))
+
+    await expect(downloadAsset(URL, dest)).rejects.toThrow('HTTP 403')
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops after one escalation — a second authenticated 403 is fatal', async () => {
+    get.mockResolvedValue(respondStatus(403))
+
+    await expect(downloadAsset(URL, dest, 'ghs-token')).rejects.toThrow('HTTP 403')
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the token attached for the remaining attempts', async () => {
+    get.mockResolvedValueOnce(respondStatus(503))
+    get.mockRejectedValueOnce(new Error('socket hang up'))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest, 'ghs-token')
+
+    expect(get.mock.calls[2][1]).toEqual({ authorization: 'Bearer ghs-token' })
+  })
+
+  it('does not escalate on a single socket reset — one blip is incidental', async () => {
+    get.mockRejectedValueOnce(new Error('socket hang up'))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest, 'ghs-token')
+
+    expect(get.mock.calls[1][1]).toBeUndefined()
+  })
+
+  it('escalates after two consecutive socket resets — persistent transport failure', async () => {
+    // 2026-08-12: five straight anonymous hang-ups killed a job while the
+    // same throttle answered every authenticated attempt first try. Two
+    // consecutive resets mean persistent, so the token goes on from there.
+    get.mockRejectedValueOnce(new Error('socket hang up'))
+    get.mockRejectedValueOnce(new Error('socket hang up'))
+    get.mockResolvedValueOnce(respondOk())
+
+    await downloadAsset(URL, dest, 'ghs-token')
+
+    expect(get.mock.calls[1][1]).toBeUndefined()
+    expect(get.mock.calls[2][1]).toEqual({ authorization: 'Bearer ghs-token' })
+  })
+
+  it('never escalates without a token, however persistent the resets', async () => {
+    get.mockRejectedValue(new Error('socket hang up'))
+
+    await expect(downloadAsset(URL, dest)).rejects.toThrow('after 5 attempts')
+    for (const call of get.mock.calls) {
+      expect(call[1]).toBeUndefined()
+    }
+  })
+
+  it('does not retry a 404 — an unpublished tag will not heal', async () => {
+    get.mockResolvedValueOnce(respondStatus(404))
+
+    await expect(downloadAsset(URL, dest)).rejects.toThrow(`Failed to download ${URL}: HTTP 404`)
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('leaves nothing on disk when every attempt truncates', async () => {
+    get.mockImplementation(async () => respondTruncated())
+
+    await expect(downloadAsset(URL, dest)).rejects.toThrow('after 5 attempts')
+    await expect(fs.access(dest)).rejects.toThrow()
+  })
+
+  it('gives up after five attempts, naming the asset URL', async () => {
+    get.mockRejectedValue(new Error('socket hang up'))
+
+    await expect(downloadAsset(URL, dest)).rejects.toThrow(
+      `Failed to download ${URL} after 5 attempts: socket hang up`
+    )
+    expect(get).toHaveBeenCalledTimes(5)
+    expect(retryLogs()).toHaveLength(4)
+  })
+
+  it('backs off ~0.5 s / 2 s / 5 s / 10 s with jitter', async () => {
+    get.mockRejectedValue(new Error('ECONNRESET'))
+
+    await expect(downloadAsset(URL, dest)).rejects.toThrow()
+
+    const [first, second, third, fourth] = delays()
+    expect(first).toBeGreaterThanOrEqual(250)
+    expect(first).toBeLessThanOrEqual(750)
+    expect(second).toBeGreaterThanOrEqual(1000)
+    expect(second).toBeLessThanOrEqual(3000)
+    expect(third).toBeGreaterThanOrEqual(2500)
+    expect(third).toBeLessThanOrEqual(7500)
+    // #79 follow-up: the tail has to outlive a sticky bad edge path (observed
+    // >8 s on 2026-08-12), not just a dropped packet.
+    expect(fourth).toBeGreaterThanOrEqual(5000)
+    expect(fourth).toBeLessThanOrEqual(15000)
+    // The logged wait is the one actually slept.
+    expect(retryLogs()[0]).toContain(`retrying in ${first} ms`)
+  })
+})
+
+/**
+ * sha256File replaces the fetched checksums.txt as the checksum side of
+ * verification — the expected value is pinned in setup.ts. Known NIST vectors,
+ * plus a multi-chunk file to catch a hash that only sees the first read.
+ */
+describe('sha256File', () => {
+  it('matches the known digest of the empty input', async () => {
+    const p = path.join(dir, 'empty')
+    await fs.writeFile(p, '')
+    expect(await sha256File(p)).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    )
+  })
+
+  it('matches the known digest of "abc"', async () => {
+    const p = path.join(dir, 'abc')
+    await fs.writeFile(p, 'abc')
+    expect(await sha256File(p)).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    )
+  })
+
+  it('hashes a file larger than one stream chunk', async () => {
+    const p = path.join(dir, 'large')
+    // 4 MiB of zeros — several 64 KiB stream chunks.
+    await fs.writeFile(p, Buffer.alloc(4 * 1024 * 1024))
+    expect(await sha256File(p)).toBe(
+      'bb9f8df61474d25e71fa00722318cd387396ca1736605e1248821cc0de3d3af8'
+    )
+  })
+})

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,7 +2,8 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as io from '@actions/io'
 import { HttpClient } from '@actions/http-client'
-import { createWriteStream, promises as fs } from 'fs'
+import { createHash } from 'crypto'
+import { createReadStream, createWriteStream, promises as fs } from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { pipeline } from 'stream/promises'
@@ -12,41 +13,161 @@ const INSTALL_DIR = '/usr/local/bin'
 const BINARY_NAME = 'cargowall'
 const CARGOWALL_VERSION = 'v1.3.6'
 
+// SHA-256 of each published binary, pinned here instead of fetched from
+// checksums.txt: a digest served by the same CDN as the binary was never a
+// trust boundary, while one that ships in the action source — which callers
+// already pin by tag or SHA — cannot be swapped by whoever is serving the
+// download. This pin is also the whole provenance story at runtime: the
+// Sigstore attestation's subject IS this digest, so byte-equality with the
+// pin proves the same artifact the attestation signs. check-digests.yml
+// verifies the attestation and the digest match against the published
+// release in CI — at pin time and continuously — which is why setup does
+// not fetch attestations.sigstore.json or shell out to `gh` per job.
+// Bump these with CARGOWALL_VERSION; check-digests.yml fails the build if
+// they drift.
+const CARGOWALL_DIGESTS = {
+  amd64: 'ac511897cb7952bc61c0a8b99d9bf73fd95148dd8062562aa3862d6c72e53865',
+  arm64: '08b56f7d25c3bd5f6c65f3bd4932bc587f049c6eb1c1a0bfc7343e8875c158f7'
+} as const
+
+type LinuxArch = keyof typeof CARGOWALL_DIGESTS
+
+function linuxArch(): LinuxArch {
+  const archRaw = os.arch()
+  switch (archRaw) {
+    case 'x64':
+      return 'amd64'
+    case 'arm64':
+      return 'arm64'
+    default:
+      throw new Error(`Unsupported architecture: ${archRaw}`)
+  }
+}
+
 const http = new HttpClient('cargowall-action')
 
+// Backoff before each retry, so five attempts in total. #79: the old single
+// 500 ms retry closed the window in ~650 ms, so one ECONNRESET from the
+// release CDN took the whole job down before the firewall ever started. The
+// ~10 s tail is sized to observed degradation: on 2026-08-12 a runner VM's
+// resets stayed sticky past an 8 s window while sibling VMs were clean, so
+// the last wait has to outlive a bad edge path, not a bad packet.
+const DOWNLOAD_RETRY_DELAYS_MS = [500, 2000, 5000, 10000]
+
+// Spread the retries of concurrently-starting jobs instead of resending them
+// in lockstep: base/2 .. base*1.5.
+function withJitter(baseMs: number): number {
+  return Math.round(baseMs / 2 + Math.random() * baseMs)
+}
+
+// Worth another attempt. Everything else (404 on a tag that isn't published)
+// is deterministic, and retrying only burns time. 403 is handled separately —
+// see the token escalation below.
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 || status === 408 || status === 429
+}
+
+// What throttling looks like from inside a runner: a load-shed 503, or a 403
+// from the anonymous rate limiter. Both are worth one authenticated re-try.
+function isThrottleStatus(status: number): boolean {
+  return status === 403 || status === 503
+}
+
+type AttemptResult = { ok: true } | { ok: false; reason: string; status: number; retryable: boolean }
+
 // Download a release asset from the public GitHub CDN, streaming to disk.
-// Intentionally sends no Authorization header: release-asset URLs 302 to a
+//
+// The first attempt is deliberately anonymous: release-asset URLs 302 to a
 // pre-signed objects.githubusercontent.com URL that rejects stray auth, and
-// staying anonymous keeps us off the installation REST rate limit.
-async function downloadAsset(url: string, dest: string): Promise<number> {
-  const attempt = async (): Promise<number> => {
-    const res = await http.get(url)
-    const status = res.message.statusCode ?? 0
-    if (status < 200 || status >= 300) {
-      res.message.resume()
-      return status
+// staying anonymous keeps us off the per-repo REST budget that
+// `skip-actions-api` exists to protect.
+//
+// #79: that also puts every request on the anonymous per-source-IP budget, and
+// hosted-runner egress is some of the hottest shared IP space there is. So on a
+// 403/503, or once transport failures look persistent rather than incidental,
+// later attempts carry `github-token` to move the github.com leg onto the
+// per-repo authenticated budget. @actions/http-client drops the Authorization
+// header when a redirect changes hostname, so the pre-signed leg stays
+// anonymous either way.
+//
+// The backoff loop is hand-rolled because allowRetries/maxRetries on
+// @actions/http-client only cover retryable status codes on idempotent verbs;
+// a socket-level reset never reaches that path.
+export async function downloadAsset(url: string, dest: string, token = ''): Promise<void> {
+  const asset = url.split('/').pop() || url
+  let authenticated = false
+
+  const attempt = async (): Promise<AttemptResult> => {
+    try {
+      const headers = authenticated ? { authorization: `Bearer ${token}` } : undefined
+      const res = await http.get(url, headers)
+      const status = res.message.statusCode ?? 0
+      if (status < 200 || status >= 300) {
+        res.message.resume()
+        return {
+          ok: false,
+          reason: `HTTP ${status}`,
+          status,
+          retryable: isRetryableStatus(status)
+        }
+      }
+      await pipeline(res.message, createWriteStream(dest))
+      return { ok: true }
+    } catch (error) {
+      // Connect-time failure (ECONNRESET, DNS, socket timeout) or a body that
+      // died mid-stream. Both are transient often enough to be worth a retry.
+      return {
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+        status: 0,
+        retryable: true
+      }
     }
-    await pipeline(res.message, createWriteStream(dest))
-    return status
   }
 
-  let status: number
-  try {
-    status = await attempt()
-  } catch {
+  for (let i = 0; ; i++) {
+    const result = await attempt()
+    if (result.ok) {
+      if (i > 0) core.info(`Downloaded ${asset} on attempt ${i + 1}`)
+      return
+    }
+
+    // Whatever reached disk is a truncated body — never leave it for the
+    // checksum step to find.
     await fs.unlink(dest).catch(() => {})
-    await sleep(500)
-    return attempt()
+
+    // Escalate once: immediately on a throttle response, or after two
+    // consecutive transport failures. The latter is evidence-driven
+    // (2026-08-12): the per-IP throttle surfaces as pre-HTTP resets as often
+    // as 503s — one job died on five straight anonymous hang-ups while every
+    // authenticated attempt that day succeeded first try. A failure with the
+    // token already attached means auth isn't the lever, so let the normal
+    // rules decide.
+    const escalate = token !== '' && !authenticated &&
+      (isThrottleStatus(result.status) || (result.retryable && i >= 1))
+    if (escalate) {
+      authenticated = true
+      core.info(`Download of ${asset} hit ${result.reason} — retrying authenticated`)
+    } else if (!result.retryable) {
+      throw new Error(`Failed to download ${url}: ${result.reason}`)
+    }
+    if (i >= DOWNLOAD_RETRY_DELAYS_MS.length) {
+      throw new Error(`Failed to download ${url} after ${i + 1} attempts: ${result.reason}`)
+    }
+
+    const delay = withJitter(DOWNLOAD_RETRY_DELAYS_MS[i])
+    core.info(
+      `Download of ${asset} failed (${result.reason}); ` +
+      `retrying in ${delay} ms — attempt ${i + 2} of ${DOWNLOAD_RETRY_DELAYS_MS.length + 1}`
+    )
+    await sleep(delay)
   }
-  if (status >= 500) {
-    await fs.unlink(dest).catch(() => {})
-    await sleep(500)
-    return attempt()
-  }
-  if (status < 200 || status >= 300) {
-    await fs.unlink(dest).catch(() => {})
-  }
-  return status
+}
+
+export async function sha256File(file: string): Promise<string> {
+  const hash = createHash('sha256')
+  await pipeline(createReadStream(file), hash)
+  return hash.digest('hex')
 }
 
 export async function setup(): Promise<boolean> {
@@ -96,30 +217,14 @@ async function installFromLocalPath(binaryPath: string): Promise<void> {
     throw new Error(`Binary not found at ${binaryPath}`)
   }
 
-  await exec.exec('chmod', ['+x', binaryPath])
-  await exec.exec('sudo', ['cp', binaryPath, path.join(INSTALL_DIR, BINARY_NAME)])
-  core.info('Installed cargowall from local path')
-
+  await installBinary(binaryPath)
   await verifyInstallation()
 }
 
 async function downloadAndInstall(): Promise<void> {
-  // Detect architecture
-  const archRaw = os.arch()
-  let arch: string
-  switch (archRaw) {
-    case 'x64':
-      arch = 'amd64'
-      break
-    case 'arm64':
-      arch = 'arm64'
-      break
-    default:
-      throw new Error(`Unsupported architecture: ${archRaw}`)
-  }
+  const arch = linuxArch()
   core.info(`Detected architecture: ${arch}`)
 
-  // Check OS
   const platform = os.platform()
   if (platform !== 'linux') {
     throw new Error(`CargoWall only supports Linux (detected: ${platform})`)
@@ -135,69 +240,31 @@ async function downloadAndInstall(): Promise<void> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cargowall-'))
   const binaryDest = path.join(tempDir, BINARY_NAME)
 
+  // Only ever used to escalate past a throttle response — see downloadAsset.
+  const token = core.getInput('github-token')
+
   try {
-    const binStatus = await downloadAsset(`${releaseBase}/${binaryAsset}`, binaryDest)
-    if (binStatus < 200 || binStatus >= 300) {
-      throw new Error(`Failed to download cargowall binary (HTTP ${binStatus})`)
-    }
+    await downloadAsset(`${releaseBase}/${binaryAsset}`, binaryDest, token)
 
-    const checksumDest = path.join(tempDir, 'checksums.txt')
-    const csStatus = await downloadAsset(`${releaseBase}/checksums.txt`, checksumDest)
-    if (csStatus < 200 || csStatus >= 300) {
-      throw new Error(`Failed to download checksums.txt (HTTP ${csStatus})`)
-    }
-
-    core.info('Verifying checksum...')
-    const checksums = await fs.readFile(checksumDest, 'utf8')
-    const expectedLine = checksums.split('\n').find(l => l.includes(binaryAsset))
-    if (!expectedLine) {
-      throw new Error(`No checksum entry for ${binaryAsset} in checksums.txt`)
-    }
-    const expectedChecksum = expectedLine.trim().split(/\s+/)[0]
-
-    let actualChecksum = ''
-    await exec.exec('sha256sum', [binaryDest], {
-      listeners: {
-        stdout: (data: Buffer) => { actualChecksum += data.toString() }
-      }
-    })
-    actualChecksum = actualChecksum.trim().split(/\s+/)[0]
-
-    if (expectedChecksum !== actualChecksum) {
-      throw new Error(`Checksum verification failed\nExpected: ${expectedChecksum}\nActual: ${actualChecksum}`)
+    core.info('Verifying checksum against pinned digest...')
+    const actualDigest = await sha256File(binaryDest)
+    if (actualDigest !== CARGOWALL_DIGESTS[arch]) {
+      throw new Error(`Checksum verification failed\nExpected: ${CARGOWALL_DIGESTS[arch]}\nActual: ${actualDigest}`)
     }
     core.info('Checksum verified')
 
-    const bundleDest = path.join(tempDir, 'attestations.sigstore.json')
-    const bundleStatus = await downloadAsset(`${releaseBase}/attestations.sigstore.json`, bundleDest)
-    if (bundleStatus < 200 || bundleStatus >= 300) {
-      throw new Error(`Failed to download attestations.sigstore.json (HTTP ${bundleStatus})`)
-    }
-
-    core.info('Verifying provenance...')
-    try {
-      await io.which('gh', true)
-    } catch {
-      throw new Error('gh CLI not found on this runner — required for provenance verification')
-    }
-    const verifyResult = await exec.exec(
-      'gh',
-      ['attestation', 'verify', binaryDest, '--bundle', bundleDest, '--repo', repo],
-      { ignoreReturnCode: true }
-    )
-    if (verifyResult !== 0) {
-      throw new Error('Provenance verification failed — binary attestation could not be confirmed')
-    }
-    core.info('Provenance verified')
-
-    await exec.exec('chmod', ['+x', binaryDest])
-    await exec.exec('sudo', ['mv', binaryDest, path.join(INSTALL_DIR, BINARY_NAME)])
-    core.info(`Installed cargowall to ${INSTALL_DIR}/${BINARY_NAME}`)
+    await installBinary(binaryDest)
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {})
   }
 
   await verifyInstallation()
+}
+
+async function installBinary(from: string): Promise<void> {
+  await exec.exec('chmod', ['+x', from])
+  await exec.exec('sudo', ['cp', from, path.join(INSTALL_DIR, BINARY_NAME)])
+  core.info(`Installed cargowall to ${INSTALL_DIR}/${BINARY_NAME}`)
 }
 
 async function verifyInstallation(): Promise<void> {


### PR DESCRIPTION
Fixes #79

Setup runs before the firewall starts, and `downloadAsset`'s single 500 ms retry — with the retry's own throw unguarded — meant one CDN blip failed the whole job with a bare `socket hang up` that read as a policy block. On 2026-08-12 the failure mode was observed live and repeatedly: bursty throttling/load-shedding of hosted-runner egress at GitHub's edge, surfacing as both socket resets and served 503s (and HTTP errors from github.com's front page in the same windows), while sibling VMs in the same second were clean and external fetches were 18/18 healthy.

## Changes

**Retry policy** — `downloadAsset` makes five attempts at ~0.5 s / 2 s / 5 s / 10 s with jitter, one code path for thrown socket errors and 5xx/408/429 alike. The ~10 s tail is sized to observed degradation: bad edge paths stayed sticky past an 8 s window, so the last wait has to outlive a bad path, not a dropped packet. Every retry is logged (attempt, asset, reason), so recovered blips are visible instead of silent and the real error rate is measurable from logs. Terminal errors carry the asset URL. 404 fails fast. Partial bodies are unlinked so the checksum step can never see a truncated download. Hand-rolled on purpose: `allowRetries` on `@actions/http-client` only covers retryable statuses on idempotent verbs, never socket-level errors.

**Token escalation** — the first attempt is always anonymous (stays off the per-repo REST budget that `skip-actions-api` protects). Escalation to `Bearer ${github-token}` happens once, on a 403/503 immediately or after two consecutive transport failures — the same per-IP throttle surfaces as pre-HTTP resets as often as 503s, and one job died on five straight anonymous hang-ups before the transport trigger existed. `@actions/http-client` drops the `Authorization` header on the hostname-changing redirect, so the pre-signed `objects.githubusercontent.com` leg stays anonymous either way.

**Pinned digests, one download** — per-arch SHA-256 digests live in `CARGOWALL_DIGESTS` next to `CARGOWALL_VERSION`. Setup now fetches exactly one asset (the binary), hashes it, and compares to the pin: `checksums.txt` was served by the same CDN as the binary and was never a trust boundary, and the runtime `gh attestation verify` proved nothing the pin doesn't — the Sigstore attestation's subject *is* the binary's SHA-256, so byte-equality with the pin proves the same artifact the attestation signs. Provenance is verified where the pin is made instead: `check-digests.yml` downloads the published binaries, compares each to the pin, and runs `gh attestation verify` on each — per push/PR and on a weekly schedule — so a stale pin, an unattested pin, or a tampered release asset fails this repo's CI, never a consumer job. Net: three CDN fetches per job → one, no runtime `gh` CLI dependency, ~4 s faster setup.

**Test harness** — positive egress checks go through a shared composite (`.github/actions/assert-egress-allowed`): a step-level probe loop where any HTTP response proves the firewall allowed the connection (github.com's edge intermittently serves 4xx/5xx to runner IPs, and curl aborts on some failures — e.g. exit 23 write errors — without retrying even under `--retry-all-errors`). A genuine block yields no response at all and still fails. Blocked-host negative assertions stay one-shot; compound assert blocks are split one-step-per-assertion so a failure names the property that broke.

**Docs** — new *Setup fails downloading the binary* troubleshooting section (failure is upstream of any policy decision; explains the aggregated-annotation confusion; arch-aware `binary-path` vendoring + caller-side `actions/cache` recipes with attestation verification), new *Binary Verification* section describing the pin-time provenance model, and `github-token`/`binary-path` descriptions in `action.yml`/README match their actual contracts.

Deliberately **not** included: an in-action cache layer via `@actions/cache` — it would grow the bundle 1.06 MB → 2.65 MB (Azure Storage SDK et al.) and add a cache trust model to avoid a release download. Persistence stays a caller choice via `binary-path`.

## Testing

- 21 tests in `src/setup.test.ts`: retry/backoff contract (reset-then-recover, 5xx/429/408, jitter bounds incl. the 5–15 s tail, exhaustion message, fail-fast 404, truncated-body cleanup on real files), escalation contract (anonymous first hop, 403/503 escalate immediately, single reset doesn't escalate, two consecutive resets do, no token → anonymous throughout, token persists across remaining attempts), and `sha256File` against independently verified vectors.
- Full suite: 154 tests across 10 files, all passing. `dist/` rebuilt: 23 bytes *smaller* than `main`.
- Validated under live fire on 2026-08-12: across the day's degradation bursts, 20 escalations fired (majority reset-triggered) and all 20 recovered on the next authenticated attempt; one recovery needed attempt 5; zero download exhaustions after the final shape landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)